### PR TITLE
chore: update to babylon labs url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-staking",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-staking",
-      "version": "0.2.25",
+      "version": "0.2.26",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@keystonehq/animated-qr": "^0.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-staking",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/components/Footer/Footer.tsx
+++ b/src/app/components/Footer/Footer.tsx
@@ -15,12 +15,12 @@ import { useTerms } from "@/app/context/Terms/TermsContext";
 const iconLinks = [
   {
     name: "Website",
-    url: "https://babylonchain.io",
+    url: "https://babylonlabs.io",
     Icon: GoHome,
   },
   {
     name: "X",
-    url: "https://twitter.com/babylon_chain",
+    url: "https://x.com/babylonlabs_io",
     Icon: FaXTwitter,
   },
   {
@@ -35,7 +35,7 @@ const iconLinks = [
   },
   {
     name: "LinkedIn",
-    url: "https://www.linkedin.com/company/babylon-chain/",
+    url: "https://www.linkedin.com/company/babylon-labs-official",
     Icon: BsLinkedin,
   },
   {
@@ -45,7 +45,7 @@ const iconLinks = [
   },
   {
     name: "Docs",
-    url: "https://docs.babylonchain.io/",
+    url: "https://docs.babylonlabs.io/",
     Icon: IoMdBook,
   },
   {

--- a/src/app/components/Modals/Terms/data/terms.tsx
+++ b/src/app/components/Modals/Terms/data/terms.tsx
@@ -12,8 +12,8 @@ export const Terms = () => {
         </a>{" "}
         is a website-hosted user interface (the{" "}
         <i className="text-primary">“Interface”</i>).{" "}
-        <a href="https://babylonchain.io" className="text-primary">
-          BabylonChain.io
+        <a href="https://babylonlabs.io" className="text-primary">
+          BabylonLabs.io
         </a>{" "}
         is our website (<i className="text-primary">“Website”</i>).
       </p>


### PR DESCRIPTION
what's miss:
1. medium url
2. mainnet url and corresponding testnet url