### PR TITLE
fix: Local storage no duplicate

### DIFF
--- a/src/app/components/Delegations/Delegations.tsx
+++ b/src/app/components/Delegations/Delegations.tsx
@@ -77,18 +77,33 @@ export const Delegations: React.FC<DelegationsProps> = ({
     delegation: DelegationInterface,
     newState: string,
   ) => {
-    setIntermediateDelegationsLocalStorage((delegations) => [
-      toLocalStorageIntermediateDelegation(
-        delegation.stakingTxHashHex,
-        publicKeyNoCoord,
-        delegation.finalityProviderPkHex,
-        delegation.stakingValueSat,
-        delegation.stakingTx.txHex,
-        delegation.stakingTx.timelock,
-        newState,
-      ),
-      ...delegations,
-    ]);
+    const newTxId = delegation.stakingTxHashHex;
+
+    setIntermediateDelegationsLocalStorage((delegations) => {
+      // Check if an intermediate delegation with the same transaction ID already exists
+      const exists = delegations.some(
+        (existingDelegation) => existingDelegation.stakingTxHashHex === newTxId,
+      );
+
+      // If it doesn't exist, add the new intermediate delegation
+      if (!exists) {
+        return [
+          toLocalStorageIntermediateDelegation(
+            newTxId,
+            publicKeyNoCoord,
+            delegation.finalityProviderPkHex,
+            delegation.stakingValueSat,
+            delegation.stakingTx.txHex,
+            delegation.stakingTx.timelock,
+            newState,
+          ),
+          ...delegations,
+        ];
+      }
+
+      // If it exists, return the existing delegations unchanged
+      return delegations;
+    });
   };
 
   // Handles unbonding requests for Active delegations that want to be withdrawn early

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -296,17 +296,33 @@ export const Staking: React.FC<StakingProps> = ({
     signedTxHex: string,
     stakingTerm: number,
   ) => {
-    setDelegationsLocalStorage((delegations) => [
-      toLocalStorageDelegation(
-        Transaction.fromHex(signedTxHex).getId(),
-        publicKeyNoCoord,
-        finalityProvider!.btcPk,
-        stakingAmountSat,
-        signedTxHex,
-        stakingTerm,
-      ),
-      ...delegations,
-    ]);
+    // Get the transaction ID
+    const newTxId = Transaction.fromHex(signedTxHex).getId();
+
+    setDelegationsLocalStorage((delegations) => {
+      // Check if the delegation with the same transaction ID already exists
+      const exists = delegations.some(
+        (delegation) => delegation.stakingTxHashHex === newTxId,
+      );
+
+      // If it doesn't exist, add the new delegation
+      if (!exists) {
+        return [
+          toLocalStorageDelegation(
+            newTxId,
+            publicKeyNoCoord,
+            finalityProvider!.btcPk,
+            stakingAmountSat,
+            signedTxHex,
+            stakingTerm,
+          ),
+          ...delegations,
+        ];
+      }
+
+      // If it exists, return the existing delegations unchanged
+      return delegations;
+    });
   };
 
   // Memoize the staking fee calculation


### PR DESCRIPTION
When trying to add an item to local storage delegations (staking) or intermediate local storage delegations (unbonding, withdrawing) using multiple Chrome extension wallet windows, we will end up add multiple items.
This PR solves it. If the item is already present in the local storage - we don't do anything.

@jeremy-babylonlabs @jrwbabylonlab when trying to "double/triple unbond", we will see this error message: https://i.imgur.com/JvtuGWp.png. Not sure if it's "good enough" for the end user.

Problems with the current PR implementation - theoretically our local storage methods `setDelegationsLocalStorage` and `setIntermediateDelegationsLocalStorage` do almost identical stuff. Should we combine them? If so - when?
- This PR contains code duplication, which is a "smell"
- "Proper" solution would require creating 2 different functions that combine/replace `handleLocalStorageDelegations` and `updateLocalStorage` (react stuff) and `setDelegationsLocalStorage` and `setIntermediateDelegationsLocalStorage`. But, we should not be placed in `FP Search / Sort` problem we had before

My suggestion - keep the PR the way it is and create an issue related to making our `localStorage` approach more concise/reusable

Maybe @vitsalis has an opinion on that also