### PR TITLE
fix: Refetch UTXOs on unsuccessful staking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
     branches:
-    - '**'
+      - "**"
 
 jobs:
   lint_test:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,10 +3,10 @@ name: docker_publish
 on:
   push:
     branches:
-    - 'main'
-    - 'dev'
+      - "main"
+      - "dev"
     tags:
-    - '*'
+      - "*"
 
 jobs:
   lint_test:
@@ -14,7 +14,7 @@ jobs:
     with:
       run-build: true
       run-unit-tests: true
-  
+
   docker_build:
     needs: [lint_test]
     runs-on: ubuntu-22.04

--- a/src/app/components/Modals/ErrorModal.tsx
+++ b/src/app/components/Modals/ErrorModal.tsx
@@ -12,6 +12,7 @@ interface ErrorModalProps {
   errorMessage: string;
   errorState?: ErrorState;
   errorTime: Date;
+  noCancel?: boolean;
 }
 
 export const ErrorModal: React.FC<ErrorModalProps> = ({
@@ -20,6 +21,7 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
   onRetry,
   errorMessage,
   errorState,
+  noCancel,
   errorTime,
 }) => {
   const { error, retryErrorAction } = useError();
@@ -93,12 +95,14 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
           <p className="text-center">{getErrorMessage()}</p>
         </div>
         <div className="mt-4 flex justify-around gap-4">
-          <button
-            className="btn btn-outline flex-1 rounded-lg px-2"
-            onClick={() => onClose()}
-          >
-            Cancel
-          </button>
+          {noCancel && (
+            <button
+              className="btn btn-outline flex-1 rounded-lg px-2"
+              onClick={() => onClose()}
+            >
+              Cancel
+            </button>
+          )}
           {onRetry && (
             <button
               className="btn-primary btn flex-1 rounded-lg px-2 text-white"

--- a/src/app/components/Modals/ErrorModal.tsx
+++ b/src/app/components/Modals/ErrorModal.tsx
@@ -22,7 +22,7 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
   errorMessage,
   errorState,
   noCancel,
-  errorTime,
+  // errorTime, // This prop is not used in the component
 }) => {
   const { error, retryErrorAction } = useError();
 
@@ -95,7 +95,7 @@ export const ErrorModal: React.FC<ErrorModalProps> = ({
           <p className="text-center">{getErrorMessage()}</p>
         </div>
         <div className="mt-4 flex justify-around gap-4">
-          {noCancel && (
+          {!noCancel && ( // Only show the cancel button if noCancel is false or undefined
             <button
               className="btn btn-outline flex-1 rounded-lg px-2"
               onClick={() => onClose()}

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -286,7 +286,13 @@ export const Staking: React.FC<StakingProps> = ({
           errorState: ErrorState.STAKING,
           errorTime: new Date(),
         },
-        retryAction: handleSign,
+        noCancel: true,
+        retryAction: () => {
+          // in case of error, we need to reset the state
+          handleResetState();
+          // and refetch the UTXOs
+          queryClient.invalidateQueries({ queryKey: [UTXO_KEY, address] });
+        },
       });
     }
   };

--- a/src/app/components/Staking/Staking.tsx
+++ b/src/app/components/Staking/Staking.tsx
@@ -288,8 +288,11 @@ export const Staking: React.FC<StakingProps> = ({
         },
         noCancel: true,
         retryAction: () => {
-          // in case of error, we need to reset the state
-          handleResetState();
+          // in case of error, we need to partly reset the state
+          setStakingAmountSat(0);
+          setSelectedFeeRate(0);
+          setPreviewModalOpen(false);
+          setResetFormInputs(!resetFormInputs);
           // and refetch the UTXOs
           queryClient.invalidateQueries({ queryKey: [UTXO_KEY, address] });
         },

--- a/src/app/context/Error/ErrorContext.tsx
+++ b/src/app/context/Error/ErrorContext.tsx
@@ -20,10 +20,12 @@ interface ErrorContextType {
   retryErrorAction?: () => void;
   showError: (showErrorParams: ShowErrorParams) => void;
   hideError: () => void;
+  noCancel?: boolean;
 }
 
 export const ErrorProvider: React.FC<ErrorProviderProps> = ({ children }) => {
   const [isErrorOpen, setIsErrorOpen] = useState(false);
+  const [isNoCancel, setIsNoCancel] = useState(false);
   const [error, setError] = useState<ErrorType>({
     message: "",
     errorTime: new Date(),
@@ -33,11 +35,15 @@ export const ErrorProvider: React.FC<ErrorProviderProps> = ({ children }) => {
     (() => void) | undefined
   >();
 
-  const showError = useCallback(({ error, retryAction }: ShowErrorParams) => {
-    setError(error);
-    setIsErrorOpen(true);
-    setRetryErrorAction(() => retryAction);
-  }, []);
+  const showError = useCallback(
+    ({ error, retryAction, noCancel }: ShowErrorParams) => {
+      setError(error);
+      setIsErrorOpen(true);
+      setIsNoCancel(noCancel ?? false);
+      setRetryErrorAction(() => retryAction);
+    },
+    [],
+  );
 
   const hideError = useCallback(() => {
     setIsErrorOpen(false);
@@ -48,6 +54,7 @@ export const ErrorProvider: React.FC<ErrorProviderProps> = ({ children }) => {
         errorState: undefined,
       });
       setRetryErrorAction(undefined);
+      setIsNoCancel(false);
     }, 300);
   }, []);
 
@@ -57,6 +64,7 @@ export const ErrorProvider: React.FC<ErrorProviderProps> = ({ children }) => {
     showError,
     hideError,
     retryErrorAction,
+    noCancel: isNoCancel,
   };
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,8 +51,14 @@ const Home: React.FC<HomeProps> = () => {
   const [publicKeyNoCoord, setPublicKeyNoCoord] = useState("");
 
   const [address, setAddress] = useState("");
-  const { error, isErrorOpen, showError, hideError, retryErrorAction } =
-    useError();
+  const {
+    error,
+    isErrorOpen,
+    showError,
+    hideError,
+    retryErrorAction,
+    noCancel,
+  } = useError();
   const { isTermsOpen, closeTerms } = useTerms();
 
   const {
@@ -470,6 +476,7 @@ const Home: React.FC<HomeProps> = () => {
         errorTime={error.errorTime}
         onClose={hideError}
         onRetry={retryErrorAction}
+        noCancel={noCancel}
       />
       <TermsModal open={isTermsOpen} onClose={closeTerms} />
     </main>

--- a/src/app/types/errors.ts
+++ b/src/app/types/errors.ts
@@ -22,4 +22,5 @@ export interface ErrorHandlerParam {
 export interface ShowErrorParams {
   error: ErrorType;
   retryAction?: () => void;
+  noCancel?: boolean;
 }


### PR DESCRIPTION
After you try to stake and some error happens, you can "Try again". Modal is closed, UTXOs are refetched.

Video recorded with the cancel button, then removed it. Only "try again" is available: https://youtu.be/-zcJTXIXqng
"No cancel" video: https://youtu.be/ETjAXdqkegE

Closes #63 