### PR TITLE
fix: exclude the oneKey from injectable wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-staking",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-staking",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@keystonehq/animated-qr": "^0.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-staking",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/components/Modals/ConnectModal.tsx
+++ b/src/app/components/Modals/ConnectModal.tsx
@@ -102,7 +102,9 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   };
 
   const buildInjectableWallet = (shouldDisplay: boolean, name: string) => {
-    if (!shouldDisplay) {
+    // NOTE: The 'OneKey (Browser)' special case here is a temporary solution
+    // while waiting for the OneKey wallet to release their fixes
+    if (!shouldDisplay || injectedWalletProviderName === "OneKey (Browser)") {
       return null;
     }
 


### PR DESCRIPTION
OneKey still haven't release their changes until now (suppose to be monday this week or even earlier)
Also realise some users may already have oneKey installed and never upgrade it, then the issue will still exist for those users.

I decide to go with this super hacky and simple approach because don't want to mess up with the injectable logic in the last minute of launch.

<img width="519" alt="image" src="https://github.com/user-attachments/assets/d4fdef8f-49e1-414c-9fae-2d42ceff6ced">

also tested on mobile
