### PR TITLE
fix: Clean out "No HW wallet checkbox" after connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-staking",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-staking",
-      "version": "0.2.41",
+      "version": "0.2.42",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@keystonehq/animated-qr": "^0.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-staking",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/components/Modals/ConnectModal.tsx
+++ b/src/app/components/Modals/ConnectModal.tsx
@@ -97,6 +97,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
       // Clean up the state
       setTermsAccepted(false);
       setNoInscription(false);
+      setNoHWWallet(false);
       setSelectedWallet("");
 
       // Connect to the wallet and close the modal


### PR DESCRIPTION
cleans out the checkbox after the connection