### PR TITLE
use correct height for unbonding model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-staking",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-staking",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@babylonlabs-io/btc-staking-ts": "0.3.0",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-staking",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/components/Modals/UnbondWithdrawModal.tsx
+++ b/src/app/components/Modals/UnbondWithdrawModal.tsx
@@ -1,8 +1,10 @@
 import { IoMdClose } from "react-icons/io";
 
+import { useGlobalParams } from "@/app/context/api/GlobalParamsProvider";
 import { getNetworkConfig } from "@/config/network.config";
 import { blocksToDisplayTime } from "@/utils/blocksToDisplayTime";
 import { satoshiToBtc } from "@/utils/btcConversions";
+import { getCurrentGlobalParamsVersion } from "@/utils/globalParams";
 import { maxDecimals } from "@/utils/maxDecimals";
 
 import { LoadingView } from "../Loading/Loading";
@@ -14,8 +16,7 @@ export const MODE_WITHDRAW = "withdraw";
 export type MODE = typeof MODE_UNBOND | typeof MODE_WITHDRAW;
 
 interface PreviewModalProps {
-  unbondingTimeBlocks: number;
-  unbondingFeeSat: number;
+  delegationHeight: number;
   open: boolean;
   onClose: (value: boolean) => void;
   onProceed: () => void;
@@ -24,8 +25,7 @@ interface PreviewModalProps {
 }
 
 export const UnbondWithdrawModal: React.FC<PreviewModalProps> = ({
-  unbondingTimeBlocks,
-  unbondingFeeSat,
+  delegationHeight,
   open,
   onClose,
   onProceed,
@@ -33,6 +33,19 @@ export const UnbondWithdrawModal: React.FC<PreviewModalProps> = ({
   awaitingWalletResponse,
 }) => {
   const { coinName, networkName } = getNetworkConfig();
+  const { data: allGlobalParamsVersions } = useGlobalParams();
+
+  const getGlobalParamsForDelegation = (startHeight: number) => {
+    const { currentVersion } = getCurrentGlobalParamsVersion(
+      startHeight,
+      allGlobalParamsVersions || [],
+    );
+    return currentVersion;
+  };
+
+  const globalParams = getGlobalParamsForDelegation(delegationHeight);
+  const unbondingFeeSat = globalParams?.unbondingFeeSat || 0;
+  const unbondingTimeBlocks = globalParams?.unbondingTime || 0;
 
   const unbondTitle = "Unbond";
 


### PR DESCRIPTION
This PR is a hotfix for the unbonding modal. It now displays the correct info according to the delegation height.

<img width="1009" alt="Screenshot 2024-10-03 at 12 29 47 AM" src="https://github.com/user-attachments/assets/62e377cc-266f-4691-836b-8108465128c5">
