### PR TITLE
feat(phase-2): delegation tabs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        environment: [devnet, phase-2-devnet, staging, testnet, mainnet-private, mainnet]
+        environment:
+          [devnet, phase-2-devnet, staging, testnet, mainnet-private, mainnet]
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository
@@ -51,7 +52,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        environment: [devnet, phase-2-devnet, staging, testnet, mainnet-private, mainnet]
+        environment:
+          [devnet, phase-2-devnet, staging, testnet, mainnet-private, mainnet]
     needs: ["docker_build"]
     steps:
       - name: Download Docker image from workspace
@@ -84,7 +86,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        environment: [devnet, phase-2-devnet, staging, testnet, mainnet-private, mainnet]
+        environment:
+          [devnet, phase-2-devnet, staging, testnet, mainnet-private, mainnet]
     needs: ["docker_build"]
     steps:
       - name: Download Docker image from workspace

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-infinite-scroll-component": "^6.1.0",
         "react-number-format": "^5.4.2",
         "react-responsive-modal": "^6.4.2",
+        "react-tabs": "^6.0.2",
         "react-tooltip": "^5.26.4",
         "sharp": "^0.33.4",
         "tailwind-merge": "^2.5.2",
@@ -15093,6 +15094,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18",
         "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-tabs": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.0.2.tgz",
+      "integrity": "sha512-aQXTKolnM28k3KguGDBSAbJvcowOQr23A+CUJdzJtOSDOtTwzEaJA+1U4KwhNL9+Obe+jFS7geuvA7ICQPXOnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/react-tooltip": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-number-format": "^5.4.2",
     "react-responsive-modal": "^6.4.2",
+    "react-tabs": "^6.0.2",
     "react-tooltip": "^5.26.4",
     "sharp": "^0.33.4",
     "tailwind-merge": "^2.5.2",

--- a/src/app/components/Delegations/DelegationTabs.tsx
+++ b/src/app/components/Delegations/DelegationTabs.tsx
@@ -1,0 +1,41 @@
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+
+import { Delegations } from "@/app/components/Delegations/Delegations";
+import { AuthGuard } from "@/components/common/AuthGuard";
+import { DelegationList } from "@/components/delegations/DelegationList";
+
+export function DelegationTabs() {
+  return (
+    <AuthGuard>
+      <Tabs>
+        <div className="card flex flex-col gap-2 bg-base-300 p-4 shadow-sm lg:flex-1">
+          <div className="flex gap-2 mb-4">
+            <h3 className="font-bold">Staking history</h3>
+
+            <TabList className="flex gap-2">
+              <Tab
+                className="text-primary cursor-pointer"
+                selectedClassName="border-b border-dashed border-primary"
+              >
+                Phase 1
+              </Tab>
+              <Tab
+                className="text-primary cursor-pointer"
+                selectedClassName="border-b border-dashed border-primary"
+              >
+                Phase 2
+              </Tab>
+            </TabList>
+          </div>
+
+          <TabPanel>
+            <Delegations />
+          </TabPanel>
+          <TabPanel>
+            <DelegationList />
+          </TabPanel>
+        </div>
+      </Tabs>
+    </AuthGuard>
+  );
+}

--- a/src/app/components/Delegations/Delegations.tsx
+++ b/src/app/components/Delegations/Delegations.tsx
@@ -42,23 +42,21 @@ export const Delegations = () => {
   }
 
   return (
-    network && (
-      <DelegationsPointsProvider
-        publicKeyNoCoord={publicKeyNoCoord}
+    <DelegationsPointsProvider
+      publicKeyNoCoord={publicKeyNoCoord}
+      delegationsAPI={delegationsAPI.delegations}
+      isWalletConnected={connected}
+      address={address}
+    >
+      <DelegationsContent
         delegationsAPI={delegationsAPI.delegations}
-        isWalletConnected={connected}
+        globalParamsVersion={currentVersion}
         address={address}
-      >
-        <DelegationsContent
-          delegationsAPI={delegationsAPI.delegations}
-          globalParamsVersion={currentVersion}
-          address={address}
-          btcWalletNetwork={network}
-          publicKeyNoCoord={publicKeyNoCoord}
-          isWalletConnected={connected}
-        />
-      </DelegationsPointsProvider>
-    )
+        btcWalletNetwork={network}
+        publicKeyNoCoord={publicKeyNoCoord}
+        isWalletConnected={connected}
+      />
+    </DelegationsPointsProvider>
   );
 };
 
@@ -287,8 +285,7 @@ const DelegationsContent: React.FC<DelegationsContentProps> = ({
       delegations;
 
   return (
-    <div className="card flex flex-col gap-2 bg-base-300 p-4 shadow-sm lg:flex-1">
-      <h3 className="mb-4 font-bold">Staking history</h3>
+    <>
       {combinedDelegationsData.length === 0 ? (
         <div className="rounded-2xl border border-neutral-content p-4 text-center dark:border-neutral-content/20">
           <p>No history found</p>
@@ -366,6 +363,6 @@ const DelegationsContent: React.FC<DelegationsContentProps> = ({
           delegation={delegation}
         />
       )}
-    </div>
+    </>
   );
 };

--- a/src/app/components/Modals/UnbondWithdrawModal.tsx
+++ b/src/app/components/Modals/UnbondWithdrawModal.tsx
@@ -24,6 +24,8 @@ interface PreviewModalProps {
   delegation: DelegationInterface;
 }
 
+const { coinName, networkName } = getNetworkConfig();
+
 export const UnbondWithdrawModal: React.FC<PreviewModalProps> = ({
   open,
   onClose,
@@ -32,8 +34,6 @@ export const UnbondWithdrawModal: React.FC<PreviewModalProps> = ({
   awaitingWalletResponse,
   delegation,
 }) => {
-  const { coinName, networkName } = getNetworkConfig();
-
   const { currentVersion: delegationGlobalParams } = useVersionByHeight(
     delegation.stakingTx.startHeight ?? 0,
   );

--- a/src/app/components/Staking/FinalityProviders/FinalityProvider.tsx
+++ b/src/app/components/Staking/FinalityProviders/FinalityProvider.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { AiOutlineInfoCircle } from "react-icons/ai";
 import { FiExternalLink } from "react-icons/fi";
 import { Tooltip } from "react-tooltip";
+import { twJoin } from "tailwind-merge";
 
 import blue from "@/app/assets/blue-check.svg";
 import { Hash } from "@/app/components/Hash/Hash";
@@ -43,11 +44,11 @@ export const FinalityProvider: React.FC<FinalityProviderProps> = ({
 
   return (
     <div
-      className={`
-        ${generalStyles}
-        ${selected ? "fp-selected" : ""}
-        ${finalityProviderHasData ? "" : "opacity-50 pointer-events-none"}
-        `}
+      className={twJoin(
+        generalStyles,
+        selected ? "fp-selected" : "",
+        finalityProviderHasData ? "" : "opacity-50 pointer-events-none",
+      )}
       onClick={handleClick}
     >
       <div className="grid grid-cols-stakingFinalityProvidersMobile grid-rows-2 items-center gap-2 lg:grid-cols-stakingFinalityProvidersDesktop lg:grid-rows-1">
@@ -72,7 +73,7 @@ export const FinalityProvider: React.FC<FinalityProviderProps> = ({
           ) : (
             <div className="flex items-center gap-1 justify-start">
               <span
-                className="cursor-pointer text-xs text-error"
+                className="cursor-pointer text-xs text-error pointer-events-auto"
                 data-tooltip-id="tooltip-missing-fp"
                 data-tooltip-content="This finality provider did not provide any information."
                 data-tooltip-place="top"
@@ -84,9 +85,11 @@ export const FinalityProvider: React.FC<FinalityProviderProps> = ({
             </div>
           )}
         </div>
+
         <div className="flex justify-end lg:justify-start">
           <Hash value={pkHex} address small noFade />
         </div>
+
         <div className="flex items-center gap-1">
           <p className="hidden sm:flex lg:hidden">Delegation:</p>
           <p>
@@ -105,6 +108,7 @@ export const FinalityProvider: React.FC<FinalityProviderProps> = ({
             className="tooltip-wrap"
           />
         </div>
+
         <div className="flex items-center justify-end gap-1 lg:justify-start">
           <p className="hidden sm:flex lg:hidden">Commission:</p>
           {finalityProviderHasData

--- a/src/app/components/Staking/FinalityProviders/FinalityProviders.tsx
+++ b/src/app/components/Staking/FinalityProviders/FinalityProviders.tsx
@@ -53,7 +53,7 @@ export const FinalityProviders: React.FC<FinalityProvidersProps> = ({
       );
       return flattenedData;
     },
-    retry: (failureCount, error) => {
+    retry: (failureCount) => {
       return !isErrorOpen && failureCount <= 3;
     },
   });

--- a/src/app/hooks/services/useDelegationService.ts
+++ b/src/app/hooks/services/useDelegationService.ts
@@ -1,0 +1,17 @@
+import { useDelegationState } from "@/app/state/DelegationState";
+
+export function useDelegationService() {
+  const {
+    delegations = [],
+    fetchMoreDelegations,
+    hasMoreDelegations,
+    isLoading,
+  } = useDelegationState();
+
+  return {
+    delegations,
+    fetchMoreDelegations,
+    hasMoreDelegations,
+    isLoading,
+  };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { initBTCCurve } from "@babylonlabs-io/btc-staking-ts";
 import { useEffect } from "react";
 
-import { Delegations } from "./components/Delegations/Delegations";
+import { DelegationTabs } from "./components/Delegations/DelegationTabs";
 import { FAQ } from "./components/FAQ/FAQ";
 import { Footer } from "./components/Footer/Footer";
 import { Header } from "./components/Header/Header";
@@ -26,7 +26,7 @@ const Home = () => {
           <Stats />
           <PersonalBalance />
           <Staking />
-          <Delegations />
+          <DelegationTabs />
         </div>
       </div>
       <FAQ />

--- a/src/components/common/AuthGuard/index.tsx
+++ b/src/components/common/AuthGuard/index.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren, ReactNode } from "react";
+
+import { useWalletConnection } from "@/app/context/wallet/WalletConnectionProvider";
+
+interface AuthGuardProps {
+  fallback?: ReactNode;
+}
+
+export function AuthGuard({
+  children,
+  fallback,
+}: PropsWithChildren<AuthGuardProps>) {
+  const { isConnected } = useWalletConnection();
+
+  return isConnected ? children : fallback;
+}

--- a/src/components/common/GridTable/components/TCell.tsx
+++ b/src/components/common/GridTable/components/TCell.tsx
@@ -1,0 +1,26 @@
+import { MouseEventHandler, type ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+interface TCellProps {
+  className?: string;
+  align?: "left" | "right" | "center";
+  children?: ReactNode;
+  onClick?: MouseEventHandler<HTMLTableCellElement>;
+}
+
+const ALIGN = {
+  left: "justify-start",
+  right: "justify-end",
+  center: "justify-center",
+} as const;
+
+export function GridCell({ className, align, children, onClick }: TCellProps) {
+  return (
+    <div
+      className={twMerge("text-left", className, align && ALIGN[align])}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/GridTable/components/THead.tsx
+++ b/src/components/common/GridTable/components/THead.tsx
@@ -1,0 +1,48 @@
+import { useCallback, type ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+import type { SortColumn } from "../types";
+
+interface THeadProps {
+  field: string;
+  title: ReactNode;
+  className?: string;
+  sortable?: boolean;
+  align?: "left" | "right" | "center";
+  sortColumn?: SortColumn;
+  onSortChange: (sortColumn: SortColumn) => void;
+}
+
+const SORT_DIRECTIONS = {
+  "": "ASC",
+  ASC: "DESC",
+  DESC: "",
+} as const;
+
+export function GridHead({
+  field,
+  title,
+  className,
+  align,
+  sortable = false,
+  sortColumn,
+  onSortChange,
+}: THeadProps) {
+  const direction = SORT_DIRECTIONS[sortColumn?.direction || ""];
+
+  const handleColumnClick = useCallback(() => {
+    if (sortable) {
+      onSortChange({ field, direction });
+    }
+  }, [field, direction, sortable, onSortChange]);
+
+  return (
+    <p
+      className={twMerge(className, sortable ? "cursor-pointer" : "")}
+      style={{ textAlign: align }}
+      onClick={handleColumnClick}
+    >
+      {title}
+    </p>
+  );
+}

--- a/src/components/common/GridTable/index.tsx
+++ b/src/components/common/GridTable/index.tsx
@@ -1,0 +1,116 @@
+import { useId } from "react";
+import InfiniteScroll from "react-infinite-scroll-component";
+import { twJoin, twMerge } from "tailwind-merge";
+
+import { LoadingTableList } from "@/app/components/Loading/Loading";
+
+import { GridCell } from "./components/TCell";
+import { GridHead } from "./components/THead";
+import type { TableColumn, TableProps } from "./types";
+import { createColumnTemplate } from "./utils";
+
+export function GridTable<R extends object, P extends object = {}>({
+  loading = false,
+  infiniteScroll = false,
+  classNames,
+  columns,
+  sortColumn,
+  fallback,
+  params = {} as P,
+  data = [],
+  getRowId,
+  onRowClick,
+  onCellClick,
+  onInfiniteScroll = () => null,
+  onSortColumn = () => null,
+}: TableProps<R, P>) {
+  const id = useId();
+
+  function handleCellClick(row: R, col: TableColumn<R, P>) {
+    return () => {
+      onRowClick?.(row);
+      onCellClick?.(row, col);
+    };
+  }
+
+  if (!data?.length) {
+    return fallback;
+  }
+
+  return (
+    <div
+      id={id}
+      className={twMerge(
+        "no-scrollbar overflow-y-auto",
+        classNames?.wrapperClassName,
+      )}
+    >
+      <InfiniteScroll
+        className={twMerge("grid", classNames?.bodyClassName)}
+        style={{
+          gridTemplateColumns: createColumnTemplate(columns),
+          overflow: "visible",
+        }}
+        dataLength={data.length}
+        next={onInfiniteScroll}
+        hasMore={infiniteScroll}
+        loader={loading ? <LoadingTableList /> : null}
+        scrollableTarget={id}
+      >
+        <div className={twMerge("contents", classNames?.headerRowClassName)}>
+          {columns.map((col) => (
+            <GridHead
+              key={col.field}
+              sortable={col.sortable}
+              field={col.field}
+              className={twMerge(
+                "sticky top-0",
+                classNames?.headerCellClassName,
+                col.headerCellClassName,
+              )}
+              title={col.headerName}
+              align={col.align}
+              sortColumn={sortColumn}
+              onSortChange={onSortColumn}
+            />
+          ))}
+        </div>
+
+        {data.map((row, i) => {
+          const rowId = getRowId(row);
+
+          return (
+            <div
+              key={getRowId(row)}
+              className={twJoin(
+                "contents",
+                typeof classNames?.rowClassName === "string"
+                  ? classNames?.rowClassName
+                  : classNames?.rowClassName?.(row, params),
+              )}
+            >
+              {columns.map((col) => (
+                <GridCell
+                  key={`${rowId}-${col.field}`}
+                  className={twMerge(
+                    typeof classNames?.cellClassName === "string"
+                      ? classNames?.cellClassName
+                      : classNames?.cellClassName?.(row, col, params),
+                    col.cellClassName,
+                  )}
+                  align={col.align}
+                  onClick={() => handleCellClick(row, col)}
+                >
+                  {col.renderCell?.(row, i, params) ??
+                    (row[col.field as keyof R] as string)}
+                </GridCell>
+              ))}
+            </div>
+          );
+        })}
+      </InfiniteScroll>
+    </div>
+  );
+}
+
+export * from "./types";

--- a/src/components/common/GridTable/types.ts
+++ b/src/components/common/GridTable/types.ts
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+
+export interface TableColumn<R extends object, P extends object = {}> {
+  field: string;
+  headerName: ReactNode;
+  cellClassName?: string;
+  headerCellClassName?: string;
+  width?: string;
+  align?: "left" | "right" | "center";
+  sortable?: boolean;
+  renderCell?: (row: R, index: number, params: P) => ReactNode;
+}
+
+export interface SortColumn {
+  field: string;
+  direction: "ASC" | "DESC" | "";
+}
+
+type RowClassNameCreator<R extends object, P extends object> = (
+  row: R,
+  param: P,
+) => string;
+type CellClassNameCreator<R extends object, P extends object> = (
+  row: R,
+  col: TableColumn<R, P>,
+  param: P,
+) => string;
+
+export interface TableProps<R extends object, P extends object = {}> {
+  loading?: boolean;
+  classNames?: {
+    wrapperClassName?: string;
+    headerCellClassName?: string;
+    headerRowClassName?: string;
+    rowClassName?: string | RowClassNameCreator<R, P>;
+    cellClassName?: string | CellClassNameCreator<R, P>;
+    bodyClassName?: string;
+    contentClassName?: string;
+  };
+  sortColumn?: SortColumn;
+  infiniteScroll?: boolean;
+  columns: TableColumn<R, P>[];
+  data: R[];
+  params?: P;
+  fallback?: ReactNode;
+  getRowId: (row: R) => string;
+  onRowClick?: (row: R) => void;
+  onCellClick?: (row: R, column: TableColumn<R, P>) => void;
+  onSortColumn?: (sortColumn: SortColumn) => void;
+  onInfiniteScroll?: () => void;
+}

--- a/src/components/common/GridTable/utils.ts
+++ b/src/components/common/GridTable/utils.ts
@@ -1,0 +1,17 @@
+import type { TableColumn } from "./types";
+
+export function createColumnTemplate<R extends object, P extends object>(
+  columns: TableColumn<R, P>[],
+) {
+  const hasWidthParam = columns.some((col) => col.width);
+
+  if (hasWidthParam) {
+    return columns.reduce((template, col) => {
+      const colWidth = col.width ?? "minmax(0, 1fr)";
+
+      return template ? `${template} ${colWidth}` : colWidth;
+    }, "");
+  }
+
+  return `repeat(${columns.length}, minmax(0, 1fr))`;
+}

--- a/src/components/common/Hint/index.tsx
+++ b/src/components/common/Hint/index.tsx
@@ -1,0 +1,26 @@
+import { type PropsWithChildren, useId } from "react";
+import { AiOutlineInfoCircle } from "react-icons/ai";
+import { Tooltip } from "react-tooltip";
+
+interface HintProps {
+  tooltip: string;
+}
+
+export function Hint({ children, tooltip }: PropsWithChildren<HintProps>) {
+  const id = useId();
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      {children && <p>{children}</p>}
+      <span
+        className="cursor-pointer text-xs"
+        data-tooltip-id={id}
+        data-tooltip-content={tooltip}
+        data-tooltip-place="top"
+      >
+        <AiOutlineInfoCircle />
+      </span>
+      <Tooltip id={id} className="tooltip-wrap" />
+    </div>
+  );
+}

--- a/src/components/delegations/DelegationList/components/ActionButton.tsx
+++ b/src/components/delegations/DelegationList/components/ActionButton.tsx
@@ -1,0 +1,38 @@
+import { DelegationState } from "../type";
+
+interface ActionButtonProps {
+  txHash: string;
+  state: string;
+  onClick?: (action: string, txHash: string) => void;
+}
+
+type ButtonAdapter = (props: ActionButtonProps) => JSX.Element;
+type ButtonStrategy = Record<string, ButtonAdapter>;
+
+const ACTION_BUTTONS: ButtonStrategy = {
+  [DelegationState.ACTIVE]: (props: ActionButtonProps) => (
+    <button
+      className="btn btn-outline btn-xs inline-flex text-sm font-normal text-primary"
+      onClick={() => props.onClick?.("unbound", props.txHash)}
+      disabled={props.state === DelegationState.INTERMEDIATE_UNBONDING}
+    >
+      Unbond
+    </button>
+  ),
+
+  [DelegationState.UNBONDED]: (props: ActionButtonProps) => (
+    <button
+      className="btn btn-outline btn-xs inline-flex text-sm font-normal text-primary"
+      onClick={() => props.onClick?.("withdraw", props.txHash)}
+      disabled={props.state === DelegationState.INTERMEDIATE_WITHDRAWAL}
+    >
+      Withdraw
+    </button>
+  ),
+};
+
+export function ActionButton(props: ActionButtonProps) {
+  const Button = ACTION_BUTTONS[props.state];
+
+  return <Button {...props} />;
+}

--- a/src/components/delegations/DelegationList/components/Amount.tsx
+++ b/src/components/delegations/DelegationList/components/Amount.tsx
@@ -1,0 +1,22 @@
+import { FaBitcoin } from "react-icons/fa";
+
+import { getNetworkConfig } from "@/config/network.config";
+import { satoshiToBtc } from "@/utils/btcConversions";
+import { maxDecimals } from "@/utils/maxDecimals";
+
+interface Amount {
+  value: number;
+}
+
+const { coinName } = getNetworkConfig();
+
+export function Amount({ value }: Amount) {
+  return (
+    <div className="inline-flex gap-1 items-center order-1 whitespace-nowrap">
+      <FaBitcoin className="text-primary" />
+      <p>
+        {maxDecimals(satoshiToBtc(value), 8)} {coinName}
+      </p>
+    </div>
+  );
+}

--- a/src/components/delegations/DelegationList/components/Overflow.tsx
+++ b/src/components/delegations/DelegationList/components/Overflow.tsx
@@ -1,0 +1,10 @@
+import { IoIosWarning } from "react-icons/io";
+
+export function Overflow() {
+  return (
+    <div className="inline-flex items-center gap-1 rounded-md bg-primary px-2 py-1 text-xs text-white">
+      <IoIosWarning size={16} />
+      <p>overflow</p>
+    </div>
+  );
+}

--- a/src/components/delegations/DelegationList/components/Status.tsx
+++ b/src/components/delegations/DelegationList/components/Status.tsx
@@ -1,0 +1,64 @@
+import { useAppState } from "@/app/state";
+import { GlobalParamsVersion } from "@/app/types/globalParams";
+import { Hint } from "@/components/common/Hint";
+import { blocksToDisplayTime } from "@/utils/blocksToDisplayTime";
+
+import { DelegationState } from "../type";
+
+interface StatusProps {
+  value: string;
+}
+
+const STATUSES: Record<
+  string,
+  (state?: GlobalParamsVersion) => { label: string; tooltip: string }
+> = {
+  [DelegationState.ACTIVE]: () => ({
+    label: "Active",
+    tooltip: "Stake is active",
+  }),
+  [DelegationState.UNBONDING_REQUESTED]: () => ({
+    label: "Unbonding Requested",
+    tooltip: "Unbonding requested",
+  }),
+  [DelegationState.UNBONDING]: (state) => ({
+    label: "Unbonding",
+    tooltip: `Unbonding process of ${blocksToDisplayTime(state?.unbondingTime)} has started`,
+  }),
+  [DelegationState.UNBONDED]: () => ({
+    label: "Unbonded",
+    tooltip: "Stake has been unbonded",
+  }),
+  [DelegationState.WITHDRAWN]: () => ({
+    label: "Withdrawn",
+    tooltip: "Stake has been withdrawn",
+  }),
+  [DelegationState.PENDING]: (state) => ({
+    label: "Pending",
+    tooltip: `Stake that is pending ${state?.confirmationDepth || 10} Bitcoin confirmations will only be visible from this device`,
+  }),
+  [DelegationState.OVERFLOW]: () => ({
+    label: "Overflow",
+    tooltip: "Stake is over the staking cap",
+  }),
+  [DelegationState.EXPIRED]: () => ({
+    label: "Expired",
+    tooltip: "Stake timelock has expired",
+  }),
+  [DelegationState.INTERMEDIATE_UNBONDING]: () => ({
+    label: "Requesting Unbonding",
+    tooltip: "Stake is requesting unbonding",
+  }),
+  [DelegationState.INTERMEDIATE_WITHDRAWAL]: () => ({
+    label: "Withdrawal Submitted",
+    tooltip: "Withdrawal transaction pending confirmation on Bitcoin",
+  }),
+};
+
+export function Status({ value }: StatusProps) {
+  const { currentVersion } = useAppState();
+  const { label = "unknown", tooltip = "unknown" } =
+    STATUSES[value](currentVersion) ?? {};
+
+  return <Hint tooltip={tooltip}>{label}</Hint>;
+}

--- a/src/components/delegations/DelegationList/components/TxHash.tsx
+++ b/src/components/delegations/DelegationList/components/TxHash.tsx
@@ -1,0 +1,21 @@
+import { getNetworkConfig } from "@/config/network.config";
+import { trim } from "@/utils/trim";
+
+const { mempoolApiUrl } = getNetworkConfig();
+
+interface TxHashProps {
+  value: string;
+}
+
+export function TxHash({ value }: TxHashProps) {
+  return (
+    <a
+      href={`${mempoolApiUrl}/tx/${value}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary hover:underline"
+    >
+      {trim(value)}
+    </a>
+  );
+}

--- a/src/components/delegations/DelegationList/index.tsx
+++ b/src/components/delegations/DelegationList/index.tsx
@@ -1,0 +1,87 @@
+import { useCurrentTime } from "@/hooks/useCurrentTime";
+import { durationTillNow } from "@/utils/formatTime";
+
+import { type TableColumn, GridTable } from "../../common/GridTable";
+
+import { ActionButton } from "./components/ActionButton";
+import { Amount } from "./components/Amount";
+import { Overflow } from "./components/Overflow";
+import { Status } from "./components/Status";
+import { TxHash } from "./components/TxHash";
+import { data } from "./mock";
+import type { Delegation, DelegationParams } from "./type";
+
+const columns: TableColumn<Delegation, DelegationParams>[] = [
+  {
+    field: "stakingValue",
+    headerName: "Amount",
+    width: "max-content",
+    renderCell: (row) => <Amount value={row.stakingValue} />,
+  },
+  {
+    field: "startHeight",
+    headerName: "Duration",
+    width: "max-content",
+    align: "center",
+  },
+  {
+    field: "startTimestamp",
+    headerName: "Inception",
+    renderCell: (row, _, params) =>
+      durationTillNow(row.startTimestamp.toString(), params.currentTime),
+  },
+  {
+    field: "txHash",
+    headerName: "Transaction hash",
+    cellClassName: "justify-center",
+    align: "center",
+    renderCell: (row) => <TxHash value={row.txHash} />,
+  },
+  {
+    field: "state",
+    headerName: "Status",
+    cellClassName: "justify-center",
+    align: "center",
+    renderCell: (row) => <Status value={row.state} />,
+  },
+  {
+    field: "points",
+    headerName: "Points",
+    align: "center",
+    width: "max-content",
+  },
+  {
+    field: "actions",
+    headerName: "Action",
+    cellClassName: "justify-center",
+    align: "center",
+    renderCell: (row) => <ActionButton txHash={row.txHash} state={row.state} />,
+  },
+  {
+    field: "overflow",
+    headerName: "",
+    width: "max-content",
+    cellClassName: "justify-center",
+    renderCell: () => <Overflow />,
+  },
+];
+
+export function DelegationList() {
+  const currentTime = useCurrentTime();
+
+  return (
+    <GridTable
+      getRowId={(row) => `${row.txHash}-${row.startHeight}`}
+      columns={columns}
+      data={data}
+      classNames={{
+        headerCellClassName: "py-2 px-4 bg-base-300",
+        wrapperClassName: "max-h-[21rem] overflow-x-auto",
+        bodyClassName: "gap-y-4 min-w-[1000px]",
+        cellClassName:
+          "p-4 first:pl-4 first:rounded-l-2xl last:pr-4 last:rounded-r-2xl bg-base-300 border dark:bg-base-200 dark:border-0 flex items-center text-sm",
+      }}
+      params={{ currentTime }}
+    />
+  );
+}

--- a/src/components/delegations/DelegationList/mock.ts
+++ b/src/components/delegations/DelegationList/mock.ts
@@ -1,3 +1,4 @@
+//TODO: remove all mocks after integration with backend
 import type { Delegation } from "./type";
 
 export const data: Delegation[] = [

--- a/src/components/delegations/DelegationList/mock.ts
+++ b/src/components/delegations/DelegationList/mock.ts
@@ -1,0 +1,52 @@
+import type { Delegation } from "./type";
+
+export const data: Delegation[] = [
+  {
+    startHeight: 1,
+    stakingValue: 10000,
+    startTimestamp: 0,
+    txHash: "51ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    state: "active",
+    points: 5,
+  },
+  {
+    startHeight: 2,
+    stakingValue: 200,
+    startTimestamp: 0,
+    txHash: "51ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    state: "active",
+    points: 5,
+  },
+  {
+    startHeight: 3,
+    stakingValue: 500,
+    startTimestamp: 0,
+    txHash: "51ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    state: "active",
+    points: 3,
+  },
+  {
+    startHeight: 1,
+    stakingValue: 10000,
+    startTimestamp: 0,
+    txHash: "51ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d52",
+    state: "active",
+    points: 5,
+  },
+  {
+    startHeight: 2,
+    stakingValue: 200,
+    startTimestamp: 0,
+    txHash: "51ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d53",
+    state: "active",
+    points: 5,
+  },
+  {
+    startHeight: 3,
+    stakingValue: 500,
+    startTimestamp: 0,
+    txHash: "51ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d54",
+    state: "active",
+    points: 3,
+  },
+];

--- a/src/components/delegations/DelegationList/type.ts
+++ b/src/components/delegations/DelegationList/type.ts
@@ -1,0 +1,25 @@
+export interface Delegation {
+  startHeight: number;
+  stakingValue: number;
+  startTimestamp: number;
+  txHash: string;
+  state: string;
+  points: number;
+}
+
+export interface DelegationParams {
+  currentTime: number;
+}
+
+export enum DelegationState {
+  ACTIVE = "active",
+  UNBONDING_REQUESTED = "unbonding_requested",
+  UNBONDING = "unbonding",
+  UNBONDED = "unbonded",
+  WITHDRAWN = "withdrawn",
+  PENDING = "pending",
+  OVERFLOW = "overflow",
+  EXPIRED = "expired",
+  INTERMEDIATE_UNBONDING = "intermediate_unbonding",
+  INTERMEDIATE_WITHDRAWAL = "intermediate_withdrawal",
+}

--- a/src/components/staking/FinalityProviders/components/Delegations.tsx
+++ b/src/components/staking/FinalityProviders/components/Delegations.tsx
@@ -1,0 +1,22 @@
+import { Hint } from "@/components/common/Hint";
+import { getNetworkConfig } from "@/config/network.config";
+import { satoshiToBtc } from "@/utils/btcConversions";
+import { maxDecimals } from "@/utils/maxDecimals";
+
+interface DelegationProps {
+  totalValue: number;
+}
+
+const { coinName } = getNetworkConfig();
+
+export function Delegations({ totalValue }: DelegationProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <p className="hidden sm:flex lg:hidden">Delegation:</p>
+      <p>
+        {maxDecimals(satoshiToBtc(totalValue), 8)} {coinName}
+      </p>
+      <Hint tooltip="Total delegation" />
+    </div>
+  );
+}

--- a/src/components/staking/FinalityProviders/components/FPEmpty.tsx
+++ b/src/components/staking/FinalityProviders/components/FPEmpty.tsx
@@ -1,0 +1,19 @@
+import { AiOutlineInfoCircle } from "react-icons/ai";
+import { Tooltip } from "react-tooltip";
+
+export function FPEmpty() {
+  return (
+    <div className="flex items-center gap-1 justify-start">
+      <span
+        className="cursor-pointer text-xs text-error "
+        data-tooltip-id="tooltip-missing-fp"
+        data-tooltip-content="This finality provider did not provide any information."
+        data-tooltip-place="top"
+      >
+        <AiOutlineInfoCircle size={16} />
+      </span>
+      <Tooltip id="tooltip-missing-fp" className="tooltip-wrap" />
+      <span>No data provided</span>
+    </div>
+  );
+}

--- a/src/components/staking/FinalityProviders/components/FPInfo.tsx
+++ b/src/components/staking/FinalityProviders/components/FPInfo.tsx
@@ -1,0 +1,30 @@
+import Image from "next/image";
+import { FiExternalLink } from "react-icons/fi";
+
+import blue from "@/app/assets/blue-check.svg";
+
+interface FPInfoProps {
+  moniker: string;
+  website: string;
+}
+
+export function FPInfo({ moniker, website }: FPInfoProps) {
+  return (
+    <div className="flex items-center gap-1 justify-start">
+      <Image src={blue} alt="verified" />
+      <p>
+        {moniker}
+        {website && (
+          <a
+            href={website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary inline-flex ml-1 relative top-[1px]"
+          >
+            <FiExternalLink />
+          </a>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/components/staking/FinalityProviders/index.tsx
+++ b/src/components/staking/FinalityProviders/index.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import { twJoin } from "tailwind-merge";
+
+import { Hash } from "@/app/components/Hash/Hash";
+import { GridTable, TableColumn } from "@/components/common/GridTable";
+import { maxDecimals } from "@/utils/maxDecimals";
+
+import { Delegations } from "./components/Delegations";
+import { FPEmpty } from "./components/FPEmpty";
+import { FPInfo } from "./components/FPInfo";
+import { data as mock } from "./mock";
+import type { Props, Row, TableParams } from "./type";
+
+const columns: TableColumn<Row, TableParams>[] = [
+  {
+    field: "moniker",
+    headerName: "Finality Provider",
+    renderCell: (row, _, { rowState }) =>
+      !rowState[row.btcPk]?.disabled ? (
+        <FPInfo moniker={row.moniker} website={row.website} />
+      ) : (
+        <FPEmpty />
+      ),
+  },
+  {
+    field: "btcPk",
+    headerName: "BTC PK",
+    renderCell: (row) => <Hash value={row.btcPk} address small noFade />,
+  },
+  {
+    field: "stake",
+    headerName: "Total Delegation",
+    renderCell: (row) => <Delegations totalValue={row.stake} />,
+  },
+  {
+    field: "commission",
+    headerName: "Commission",
+    renderCell: (row, _, { rowState }) =>
+      !rowState[row.btcPk]?.disabled
+        ? `${maxDecimals(Number(row.commission) * 100, 2)}%`
+        : "-",
+  },
+];
+
+// Just a workaround for Finality Providers. Ignore it for now.
+export function FinalityProviders({
+  selectedRow,
+  data = mock,
+  onRowSelect,
+}: Props) {
+  const rowState = useMemo(
+    () =>
+      data.reduce(
+        (rowState, row) => ({
+          ...rowState,
+          [row.btcPk]: {
+            selected: row.btcPk === selectedRow,
+            disabled: !(row.moniker && row.stake && row.btcPk),
+          },
+        }),
+        {} as TableParams["rowState"],
+      ),
+    [data, selectedRow],
+  );
+
+  return (
+    <GridTable
+      columns={columns}
+      data={data}
+      getRowId={(row) => row.btcPk}
+      params={{ rowState }}
+      classNames={{
+        headerRowClassName: "mb-4",
+        wrapperClassName: "max-h-[21rem]",
+        bodyClassName: "gap-y-4",
+        rowClassName: (row, { rowState }) =>
+          twJoin(
+            "text-sm",
+            rowState[row.btcPk]?.disabled
+              ? "[&>div]:opacity-50 [&>div]:pointer-events-none"
+              : "",
+            rowState[row.btcPk]?.selected ? "" : "",
+          ),
+        cellClassName:
+          "py-4 first:pl-4 first:rounded-l-2xl first:border-l last:pr-4 last:rounded-r-2xl last:border-r bg-base-300  border-y dark:bg-base-200 dark:!border-0 flex items-center",
+      }}
+      onRowClick={(row) => {
+        onRowSelect(row.btcPk);
+      }}
+    />
+  );
+}

--- a/src/components/staking/FinalityProviders/mock.ts
+++ b/src/components/staking/FinalityProviders/mock.ts
@@ -1,0 +1,67 @@
+import type { Row } from "./type";
+
+export const data: Row[] = [
+  {
+    moniker: "test",
+    btcPk: "11ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test 1",
+    btcPk: "21ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 0,
+    commission: 0,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test 1",
+    btcPk: "31ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test",
+    btcPk: "41ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test 1",
+    btcPk: "51ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test 1",
+    btcPk: "61ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test",
+    btcPk: "71ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test 1",
+    btcPk: "81ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+  {
+    moniker: "test 1",
+    btcPk: "91ff556a3e993733b739e62aa390513db428943787cd88f5fe2ee95a4d3a8d51",
+    stake: 1000000,
+    commission: 0.5,
+    website: "http://google.com",
+  },
+];

--- a/src/components/staking/FinalityProviders/type.ts
+++ b/src/components/staking/FinalityProviders/type.ts
@@ -1,0 +1,17 @@
+export type Row = {
+  moniker: string;
+  btcPk: string;
+  stake: number;
+  commission: number;
+  website: string;
+};
+
+export type TableParams = {
+  rowState: Record<string, { selected: boolean; disabled: boolean }>;
+};
+
+export interface Props {
+  selectedRow: string;
+  data: Row[];
+  onRowSelect: (pk: string) => void;
+}

--- a/src/hooks/useCurrentTime.tsx
+++ b/src/hooks/useCurrentTime.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+import { ONE_MINUTE } from "@/app/constants";
+
+export function useCurrentTime(refreshInterval: number = 60 * ONE_MINUTE) {
+  const [currentTime, setCurrentTime] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timerId = setInterval(() => {
+      setCurrentTime(Date.now());
+    }, refreshInterval);
+
+    return () => clearInterval(timerId);
+  }, [refreshInterval]);
+
+  return currentTime;
+}


### PR DESCRIPTION
- Added new GridTable component
- Created static UI for Phase-2 Delegations
- Implemented FP table on top of GridTable, but didn't replace existing one (cause new component doesn't have mobile version atm)
- Split delegations into 2 tabs

### Before
<img width="1388" alt="Screenshot 2024-10-24 at 18 37 11" src="https://github.com/user-attachments/assets/62886bef-56cf-4cef-b725-8364c84abcab">

### After
<img width="1521" alt="Screenshot 2024-10-24 at 18 33 24" src="https://github.com/user-attachments/assets/332ac317-3293-4ef2-bda9-32f7bbcb80dd">

