### PR TITLE
feature: Pending verification modal

### DIFF
--- a/src/app/components/Modals/PendingVerificationModal.tsx
+++ b/src/app/components/Modals/PendingVerificationModal.tsx
@@ -1,0 +1,71 @@
+import { FaCheckCircle } from "react-icons/fa";
+
+import { getNetworkConfig } from "@/config/network.config";
+
+import { GeneralModal } from "./GeneralModal";
+
+interface PendingVerificationModalProps {
+  open: boolean;
+  onClose: (value: boolean) => void;
+  verified: boolean;
+  onStake?: () => void;
+  awaitingWalletResponse: boolean;
+}
+
+const Verified = () => (
+  <>
+    <FaCheckCircle className="text-5xl text-success" />
+    <h3 className="text-xl text-center">Verified</h3>
+    <p className="text-sm text-center">
+      Your request has been verified by the babylon blockchain. You can now
+      stake
+    </p>
+  </>
+);
+
+const NotVerified = () => (
+  <>
+    <span className="loading loading-spinner loading-lg text-primary" />
+    <h3 className="text-xl text-center">Pending Verification</h3>
+    <p className="text-sm text-center">
+      The babylon blockchain has received your request. Please wait while we
+      confirm the neseccary amount of signatures
+    </p>
+  </>
+);
+
+export function PendingVerificationModal({
+  open,
+  onClose,
+  verified,
+  onStake,
+  awaitingWalletResponse,
+}: PendingVerificationModalProps) {
+  const { networkName } = getNetworkConfig();
+
+  return (
+    <GeneralModal
+      open={open}
+      onClose={onClose}
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
+    >
+      <div className="flex flex-col gap-8 md:max-w-[34rem]">
+        <div className="py-4 flex flex-col items-center gap-4">
+          {verified ? <Verified /> : <NotVerified />}
+        </div>
+        <button
+          className="btn btn-primary"
+          disabled={!verified || awaitingWalletResponse}
+          onClick={onStake}
+        >
+          {awaitingWalletResponse ? (
+            <span className="loading loading-spinner"></span>
+          ) : (
+            <span>Stake on {networkName}</span>
+          )}
+        </button>
+      </div>
+    </GeneralModal>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { initBTCCurve } from "@babylonlabs-io/btc-staking-ts";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { DelegationTabs } from "./components/Delegations/DelegationTabs";
 import { FAQ } from "./components/FAQ/FAQ";
 import { Footer } from "./components/Footer/Footer";
 import { Header } from "./components/Header/Header";
 import { FilterOrdinalsModal } from "./components/Modals/FilterOrdinalsModal";
-import { PendingVerificationModal } from "./components/Modals/PendingVerificationModal";
 import { NetworkBadge } from "./components/NetworkBadge/NetworkBadge";
 import { PersonalBalance } from "./components/PersonalBalance/PersonalBalance";
 import { Staking } from "./components/Staking/Staking";
@@ -19,34 +18,8 @@ const Home = () => {
     initBTCCurve();
   }, []);
 
-  // TODO remove
-  const [pendingVerificationOpen, setPendingVerificationOpen] = useState(false);
-  const [verified, setVerified] = useState(false);
-  const [awaitingWalletResponse, setAwaitingWalletResponse] = useState(false);
-  const handlePendingOpen = async () => {
-    // open the modal
-    setPendingVerificationOpen(true);
-    await new Promise((resolve) => setTimeout(resolve, 3000)); // simulate waiting for BBN verification
-    setVerified(true);
-  };
-  const handlePendingClose = () => {
-    // clean out the state
-    setVerified(false);
-    setAwaitingWalletResponse(false);
-    setPendingVerificationOpen(false);
-  };
-  const handleStakeSignBroadcast = async () => {
-    console.log("start staking");
-    setAwaitingWalletResponse(true); // waiting for wallet response
-    await new Promise((resolve) => setTimeout(resolve, 3000));
-    setAwaitingWalletResponse(false);
-    console.log("staking done");
-    handlePendingClose();
-  };
-
   return (
     <>
-      <button onClick={handlePendingOpen}>Pending</button>
       <NetworkBadge />
       <Header />
       <div className="container mx-auto flex justify-center p-6">
@@ -60,13 +33,6 @@ const Home = () => {
       <FAQ />
       <Footer />
       <FilterOrdinalsModal />
-      <PendingVerificationModal
-        open={pendingVerificationOpen}
-        onClose={handlePendingClose}
-        verified={verified}
-        onStake={handleStakeSignBroadcast}
-        awaitingWalletResponse={awaitingWalletResponse}
-      />
     </>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { initBTCCurve } from "@babylonlabs-io/btc-staking-ts";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { DelegationTabs } from "./components/Delegations/DelegationTabs";
 import { FAQ } from "./components/FAQ/FAQ";
 import { Footer } from "./components/Footer/Footer";
 import { Header } from "./components/Header/Header";
 import { FilterOrdinalsModal } from "./components/Modals/FilterOrdinalsModal";
+import { PendingVerificationModal } from "./components/Modals/PendingVerificationModal";
 import { NetworkBadge } from "./components/NetworkBadge/NetworkBadge";
 import { PersonalBalance } from "./components/PersonalBalance/PersonalBalance";
 import { Staking } from "./components/Staking/Staking";
@@ -18,8 +19,34 @@ const Home = () => {
     initBTCCurve();
   }, []);
 
+  // TODO remove
+  const [pendingVerificationOpen, setPendingVerificationOpen] = useState(false);
+  const [verified, setVerified] = useState(false);
+  const [awaitingWalletResponse, setAwaitingWalletResponse] = useState(false);
+  const handlePendingOpen = async () => {
+    // open the modal
+    setPendingVerificationOpen(true);
+    await new Promise((resolve) => setTimeout(resolve, 3000)); // simulate waiting for BBN verification
+    setVerified(true);
+  };
+  const handlePendingClose = () => {
+    // clean out the state
+    setVerified(false);
+    setAwaitingWalletResponse(false);
+    setPendingVerificationOpen(false);
+  };
+  const handleStakeSignBroadcast = async () => {
+    console.log("start staking");
+    setAwaitingWalletResponse(true); // waiting for wallet response
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    setAwaitingWalletResponse(false);
+    console.log("staking done");
+    handlePendingClose();
+  };
+
   return (
     <>
+      <button onClick={handlePendingOpen}>Pending</button>
       <NetworkBadge />
       <Header />
       <div className="container mx-auto flex justify-center p-6">
@@ -33,6 +60,13 @@ const Home = () => {
       <FAQ />
       <Footer />
       <FilterOrdinalsModal />
+      <PendingVerificationModal
+        open={pendingVerificationOpen}
+        onClose={handlePendingClose}
+        verified={verified}
+        onStake={handleStakeSignBroadcast}
+        awaitingWalletResponse={awaitingWalletResponse}
+      />
     </>
   );
 };


### PR DESCRIPTION
Addition of Pending Verification modal with the current design

To use it:

```tsx
  const [pendingVerificationOpen, setPendingVerificationOpen] = useState(false);
  const [verified, setVerified] = useState(false);
  const [awaitingWalletResponse, setAwaitingWalletResponse] = useState(false);
  const handlePendingOpen = async () => {
    // open the modal
    setPendingVerificationOpen(true);
    await new Promise((resolve) => setTimeout(resolve, 3000)); // simulate waiting for BBN verification
    setVerified(true);
  };
  const handlePendingClose = () => {
    // clean out the state
    setVerified(false);
    setAwaitingWalletResponse(false);
    setPendingVerificationOpen(false);
  };
  const handleStakeSignBroadcast = async () => {
    console.log("start staking");
    setAwaitingWalletResponse(true); // waiting for wallet response
    await new Promise((resolve) => setTimeout(resolve, 3000));
    setAwaitingWalletResponse(false);
    console.log("staking done");
    handlePendingClose();
  };
```

Video: https://youtu.be/6bIyE6O3vIk

Things that should be added to this modal:
1. We should poll for a delegation. If it's verified - change the verified flag. Back-end endpoint to be provided by @jeremy-babylonlabs 
2. Local storage. TX should be saved to local storage, to show that it's pending verification. Once verified - we can click the button (either in modal or in delegations table) to sign the staking tx and broadcast it to BTC