### PR TITLE
Tong/change to static export

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -206,12 +206,6 @@ jobs:
       - name: Archive output
         run: tar -czvf /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz -C out .
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: simple-staking-${{ matrix.environment }}
-          path: /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz
-
       - name: Upload to S3 with commit sha
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -210,7 +210,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "ap-east-1"
+          AWS_REGION: ${{ vars.AWS_S3_REGION }}
         run: aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET }}/${{ matrix.environment }}/simple-staking-${{ github.sha }}.tar.gz
 
       - name: Upload to S3 with Git Tag
@@ -218,5 +218,5 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "ap-east-1"
+          AWS_REGION: ${{ vars.AWS_S3_REGION }}
         run: aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET }}/${{ matrix.environment }}/simple-staking-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -157,3 +157,72 @@ jobs:
         run: |
           docker tag simple-staking:${{ github.sha }} ${{ vars.AWS_ECR_REGISTRY_ID }}/simple-staking:${{ github.ref_name }}-${{ matrix.environment }}
           docker push ${{ vars.AWS_ECR_REGISTRY_ID }}/simple-staking:${{ github.ref_name }}-${{ matrix.environment }}
+
+  s3_publish:
+    needs: [lint_test]
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        environment:
+          [
+            devnet,
+            phase-2-devnet,
+            testnet,
+            phase-2-testnet,
+            mainnet-private,
+            phase-2-private-mainnet,
+            mainnet,
+            phase-2-mainnet,
+            mock-mainnet,
+          ]
+    environment: ${{ matrix.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+        env:
+          NEXT_PUBLIC_MEMPOOL_API: ${{ vars.NEXT_PUBLIC_MEMPOOL_API }}
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_NETWORK: ${{ vars.NEXT_PUBLIC_NETWORK }}
+          NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES: ${{ vars.NEXT_PUBLIC_DISPLAY_TESTING_MESSAGES }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_FIXED_STAKING_TERM: ${{ vars.NEXT_PUBLIC_FIXED_STAKING_TERM }}
+          NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}
+          NEXT_PUBLIC_BBN_GAS_PRICE: ${{ vars.NEXT_PUBLIC_BBN_GAS_PRICE }}
+          NEXT_PUBLIC_SIDECAR_API_URL: ${{ vars.NEXT_PUBLIC_SIDECAR_API_URL }}
+          S3_PUBLIC_BUCKET: ${{ vars.S3_PUBLIC_BUCKET }}
+
+      - name: Archive output
+        run: tar -czvf /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz -C out .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: simple-staking-${{ matrix.environment }}
+          path: /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz
+
+      - name: Upload to S3 with commit sha
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "ap-east-1"
+        run: aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET }}/${{ matrix.environment }}/simple-staking-${{ github.sha }}.tar.gz
+
+      - name: Upload to S3 with Git Tag
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "ap-east-1"
+        run: aws s3 cp /tmp/simple-staking-${{ matrix.environment }}-${{ github.sha }}.tar.gz s3://${{ vars.S3_PUBLIC_BUCKET }}/${{ matrix.environment }}/simple-staking-${{ github.ref_name }}.tar.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,9 @@ COPY tailwind.config.ts .
 COPY postcss.config.js .
 COPY sentry.client.config.ts .
 
+RUN sed -i '/images: { unoptimized: true },/d' next.config.mjs && \
+    sed -i 's/output: "export"/output: "standalone"/' next.config.mjs
+
 ARG NEXT_PUBLIC_MEMPOOL_API
 ENV NEXT_PUBLIC_MEMPOOL_API=${NEXT_PUBLIC_MEMPOOL_API}
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,7 +3,8 @@ import { withSentryConfig } from "@sentry/nextjs";
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: false,
-  output: "standalone",
+  output: "export",
+  images: { unoptimized: true },
   experimental: {
     forceSwcTransforms: true,
   },


### PR DESCRIPTION
~~DO NOT MERGE UNTIL WE FIGURE OUT THE DEPLOYMENT~~

It's pretty straight forward to change NextJs to export static assets. The good news is that we don't actually use any server specific features so far so the build is successful, otherwise it would fail. See more: https://nextjs.org/docs/14/app/building-your-application/deploying/static-exports#unsupported-features
The only thing we need to turn off is the image optimization.

If we really want to move towards this approach, we need to figure out the new deployment approach. We could probably deploy that to S3 for example but I don't think i have enough permission to explore or setup that.
