### PR TITLE
CI: Enable Dockerfile and image scanning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,8 +40,8 @@ FROM node:22-alpine3.19 AS runner
 WORKDIR /app
 
 # Don't run production as root
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
 USER nextjs
 
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
This repository is not using reusable pipeline
Remaining CVEs:
<table>
    <tr>
        <th>Package</th>
        <th>ID</th>
        <th>Severity</th>
        <th>Installed Version</th>
        <th>Fixed Version</th>
    </tr>
    <tr>
        <td><code>cross-spawn</code></td>
        <td>CVE-2024-21538</td>
        <td>HIGH</td>
        <td>7.0.3</td>
        <td>7.0.5</td>
    </tr>
</table>