### PR TITLE
fix: inception unable to handle  months and years

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-staking",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-staking",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "dependencies": {
         "@babylonlabs-io/btc-staking-ts": "0.3.0",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-staking",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -10,17 +10,30 @@ interface Duration {
   seconds?: number;
 }
 
-export const durationTillNow = (time: string, currentTime: number) => {
-  if (!time || time.startsWith("000")) return "Ongoing";
+export const durationTillNow = (
+  startTimestamp: string,
+  currentTime: number,
+) => {
+  if (!startTimestamp || startTimestamp.startsWith("000")) return "Ongoing";
 
   const duration = intervalToDuration({
     end: currentTime,
-    start: new Date(time),
+    start: new Date(startTimestamp),
   });
-  let format: (keyof Duration)[] = ["days", "hours", "minutes"];
 
-  if (!duration.days && !duration.hours && !duration.minutes) {
-    format.push("seconds");
+  let format: (keyof Duration)[] = [];
+
+  // If there are months or years, only show months and days
+  if (duration.months || duration.years) {
+    format = ["years", "months", "days"];
+  }
+  // If only days or less, show more detailed time
+  else {
+    format = ["days", "hours", "minutes"];
+    // Add seconds only if less than a minute
+    if (!duration.days && !duration.hours && !duration.minutes) {
+      format.push("seconds");
+    }
   }
 
   const formattedTime = formatDuration(duration, {


### PR DESCRIPTION
The issue was that we weren’t handling months and years properly, but now we do. Additionally, I’ve removed hours and minutes when displaying months or years, as including too much detail would make the field unnecessarily lengthy.


<img width="888" alt="image" src="https://github.com/user-attachments/assets/194e6366-4b57-4523-b0f6-db921bb11d1f" />


<img width="929" alt="image" src="https://github.com/user-attachments/assets/7a949c6f-f28a-4df8-b913-46764120fdbd" />
