### PR TITLE
re-placement of testnet badge

### DIFF
--- a/src/app/components/NetworkBadge/NetworkBadge.tsx
+++ b/src/app/components/NetworkBadge/NetworkBadge.tsx
@@ -1,30 +1,26 @@
 import Image from "next/image";
 import { twJoin } from "tailwind-merge";
 
-import { useBTCWallet } from "@/app/context/wallet/BTCWalletProvider";
 import { network } from "@/config/network.config";
 import { Network } from "@/utils/wallet/btc_wallet_provider";
 
 import testnetIcon from "./testnet-icon.png";
 
 export const NetworkBadge = () => {
-  const { connected } = useBTCWallet();
-
   return (
-    <div
-      className={twJoin(
-        `absolute left-2`,
-        connected ? "top-40 md:top-24 lg:top-32" : "top-24 md:top-24 lg:top-32",
-      )}
-    >
+    <div className={twJoin(`absolute left-2 top-7`)}>
       {[Network.SIGNET, Network.TESTNET].includes(network) && (
         <>
-          <Image src={testnetIcon} alt="Testnet" className="w-[10rem]" />
+          <Image
+            src={testnetIcon}
+            alt="Testnet"
+            className="w-[4rem] md:w-[7rem]"
+          />
           {/*
             currently the text is absolutely positioned
             since the image has a shadow
           */}
-          <p className="absolute left-4 top-[4rem] text-sm dark:text-neutral-content">
+          <p className="absolute left-1 top-[1rem] md:top-[2rem] text-sm text-secondary-contrast">
             Testnet
           </p>
         </>


### PR DESCRIPTION
The testnet badge now will be on the left of the BBL icon.

<img width="331" alt="image" src="https://github.com/user-attachments/assets/6c21ceb0-f021-4666-a1a7-a8c5492e96cf" />

<img width="232" alt="image" src="https://github.com/user-attachments/assets/19a8833e-1625-4e94-955b-39e80d2ee9d9" />
