### PR TITLE
add claim reward modal

### DIFF
--- a/src/app/components/Modals/ClaimRewardModal.tsx
+++ b/src/app/components/Modals/ClaimRewardModal.tsx
@@ -1,0 +1,58 @@
+import { Heading, Text } from "@babylonlabs-io/bbn-core-ui";
+import { PropsWithChildren } from "react";
+
+import { ConfirmationModal } from "./ConfirmationModal";
+
+interface ConfirmationModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  receivingValue: string;
+  address: string;
+  transactionFee: string;
+}
+
+export const ClaimRewardModal = ({
+  open,
+  onClose,
+  onSubmit,
+  receivingValue,
+  address,
+  transactionFee,
+}: PropsWithChildren<ConfirmationModalProps>) => {
+  return (
+    <ConfirmationModal
+      open={open}
+      processing={false}
+      title="Claim tBABY Reward"
+      onClose={onClose}
+      onSubmit={onSubmit}
+    >
+      <div className="flex flex-col mt-8 gap-10">
+        <div className="flex flex-col gap-4 divide-y divide-inherit">
+          <div className="flex flex-row items-center justify-between">
+            <Text variant="body1" className="text-center">
+              Receiving
+            </Text>
+            <Text variant="body1">{receivingValue} tBABY</Text>
+          </div>
+
+          <div className="flex flex-row items-center justify-between pt-4">
+            <Text variant="body1">Babylon Test ChainAddress</Text>
+            <Text variant="body1">{address}</Text>
+          </div>
+          <div className="flex flex-row items-center justify-between pt-4">
+            <Text variant="body1">Transaction Fees</Text>
+            <Text variant="body1">{transactionFee} tBABY</Text>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4 mb-10">
+          <Heading variant="h6">Attension!</Heading>
+          <Text variant="body2">
+            Processing your claim will take approximately 2 blocks to complete.
+          </Text>
+        </div>
+      </div>
+    </ConfirmationModal>
+  );
+};

--- a/src/app/components/Notification/NotificationContainer.tsx
+++ b/src/app/components/Notification/NotificationContainer.tsx
@@ -28,7 +28,7 @@ export const NotificationContainer = () => {
       closeButton={false}
       icon={false}
       hideProgressBar={true}
-      position={isMobileView ? "top-center" : "top-right"}
+      position={isMobileView ? "top-center" : "bottom-center"}
     />
   );
 };

--- a/src/app/components/Notification/NotificationText.tsx
+++ b/src/app/components/Notification/NotificationText.tsx
@@ -4,8 +4,6 @@ interface Props {
 
 export const NotificationText = ({ children }: Props) => {
   return (
-    <span className="text-sm font-normal dark:text-[#AFAFAF] text-[#303030]">
-      {children}
-    </span>
+    <span className="text-sm font-normal text-primary-dark">{children}</span>
   );
 };

--- a/src/app/components/Notification/NotificationTitle.tsx
+++ b/src/app/components/Notification/NotificationTitle.tsx
@@ -4,8 +4,6 @@ interface Props {
 
 export const NotificationTitle = ({ children }: Props) => {
   return (
-    <span className="text-base font-bold dark:text-white text-black">
-      {children}
-    </span>
+    <span className="text-base font-bold text-primary-dark">{children}</span>
   );
 };

--- a/src/app/components/PersonalBalance/PersonalBalance.tsx
+++ b/src/app/components/PersonalBalance/PersonalBalance.tsx
@@ -1,14 +1,17 @@
 import { Heading } from "@babylonlabs-io/bbn-core-ui";
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 
 import { useBTCWallet } from "@/app/context/wallet/BTCWalletProvider";
 import { useCosmosWallet } from "@/app/context/wallet/CosmosWalletProvider";
 import { useBbnQuery } from "@/app/hooks/client/rpc/queries/useBbnQuery";
 import { useRewardsService } from "@/app/hooks/services/useRewardsService";
+import { notifySuccess } from "@/app/hooks/useNotification";
 import { getNetworkConfig } from "@/config/network.config";
 import { ubbnToBbn } from "@/utils/bbn";
 import { satoshiToBtc } from "@/utils/btc";
 
+import { ClaimRewardModal } from "../Modals/ClaimRewardModal";
 import { StatItem } from "../Stats/StatItem";
 
 const QUERY_KEYS = {
@@ -31,6 +34,14 @@ export function PersonalBalance() {
   } = useBbnQuery();
   const { claimRewards } = useRewardsService();
   const { rewardsQuery } = useBbnQuery();
+  const [showClaimRewardModal, setShowClaimRewardModal] = useState(false);
+
+  const claimAction = async () => {
+    setShowClaimRewardModal(false);
+    notifySuccess("Claim Processing", "more info");
+    await claimRewards();
+    notifySuccess("Successfully Claimed tBABY", "more info");
+  };
 
   const { data: btcBalance, isLoading: btcBalanceLoading } = useQuery({
     queryKey: [QUERY_KEYS.BTC_BALANCE],
@@ -80,10 +91,18 @@ export function PersonalBalance() {
           value={`${ubbnToBbn(rewardsQuery.data ?? 0)} BBN`}
           actionComponent={{
             title: "Claim",
-            onAction: claimRewards,
+            onAction: () => setShowClaimRewardModal(true),
           }}
         />
       </div>
+      <ClaimRewardModal
+        open={showClaimRewardModal}
+        onClose={() => setShowClaimRewardModal(false)}
+        onSubmit={claimAction}
+        receivingValue={`${ubbnToBbn(rewardsQuery.data ?? 0)}`}
+        address="(placeholder)bbn170...e9m94d"
+        transactionFee="(placeholder)0.050"
+      />
     </div>
   );
 }


### PR DESCRIPTION
<img width="520" alt="image" src="https://github.com/user-attachments/assets/3d69f658-a989-4f29-bf5e-9d30396b1924" />

<img width="717" alt="image" src="https://github.com/user-attachments/assets/0bc9582d-dbeb-42f1-9016-86a83e59e8a7" />


When the "Claim" button is clicked, the modal in the above image shoud display.
Note: I have place in a few placeholders since I have no idea where to get those value from.

When the "Proceed" button is clicked on the modal, it will send a notification and when the claim action was successful, a success notification will be send after that.
Note: We might need a redesign of the notification banners but I have no idea if the design is ready so I will leave it for now.