### PR TITLE
feat: Testnet env

### DIFF
--- a/src/config/network/btc.ts
+++ b/src/config/network/btc.ts
@@ -41,8 +41,9 @@ export function getNetworkConfigBTC(): BTCConfig {
       return config.mainnet;
     case Network.SIGNET:
       return config.signet;
+    // we do not use Testnet
     case Network.TESTNET:
-      return config.testnet;
+      return config.signet;
     default:
       return config.signet;
   }


### PR DESCRIPTION
This PR introduces such network combos based on the env variable:

- mainnet
    - btc mainnet
    - bbn testnet
- testnet
    - btc signet
    - bbn testnet
- signet
    - btc signet
    - bbn devnet


@jeremy-babylonlabs @jrwbabylonlab @totraev @hiepmai-babylonchain 
question, do we want to change `BBN` signet config from

```ts
const signetConfig: BBNConfig = {
  chainId: bbnDevnet.chainId,
  rpc: bbnDevnet.rpc,
  chainData: bbnDevnet,
  networkName: "Testnet BABY",
  networkFullName: "Testnet Babylon Chain",
  coinSymbol: "tBABY",
};
```

to
```ts
const signetConfig: BBNConfig = {
  chainId: bbnDevnet.chainId,
  rpc: bbnDevnet.rpc,
  chainData: bbnDevnet,
  networkName: "Devnet BABY",
  networkFullName: "Devnet Babylon Chain",
  coinSymbol: "dBABY",
};
```

So it's visible for the user (and us) that `devnet` chain is used. Because right now if we use `signet` env, it will use `devnet` chain, but it will write `Testnet Babylon Chain` and `Testnet BABY`