### PR TITLE
fix: refetch v1 delegations after register to phase-2

### DIFF
--- a/src/app/components/Delegations/Delegation.tsx
+++ b/src/app/components/Delegations/Delegation.tsx
@@ -7,7 +7,6 @@ import { RegistrationStartModal } from "@/app/components/Modals/RegistrationModa
 import { SignModal } from "@/app/components/Modals/SignModal/SignModal";
 import { ONE_MINUTE } from "@/app/constants";
 import { useRegistrationService } from "@/app/hooks/services/useRegistrationService";
-import { useHealthCheck } from "@/app/hooks/useHealthCheck";
 import { useDelegationState } from "@/app/state/DelegationState";
 import { useFinalityProviderState } from "@/app/state/FinalityProviderState";
 import {
@@ -68,7 +67,6 @@ export const Delegation: React.FC<DelegationProps> = ({
 
   const { startTimestamp } = stakingTx;
   const [currentTime, setCurrentTime] = useState(Date.now());
-  const { isApiNormal, isGeoBlocked } = useHealthCheck();
   const {
     processing,
     registrationStep: step,

--- a/src/app/hooks/services/useRegistrationService.ts
+++ b/src/app/hooks/services/useRegistrationService.ts
@@ -27,9 +27,11 @@ export function useRegistrationService() {
     setProcessing,
     selectedDelegation,
     resetRegistration: reset,
+    refetch: refetchV1Delegations,
   } = useDelegationState();
   const { transitionPhase1Delegation } = useTransactionService();
-  const { addDelegation } = useDelegationV2State();
+  const { addDelegation, refetch: refetchV2Delegations } =
+    useDelegationV2State();
   const { showError } = useError();
 
   const registerPhase1Delegation = useCallback(async () => {
@@ -85,6 +87,9 @@ export function useRegistrationService() {
       );
       if (delegation) {
         setStep("registration-verified");
+        // Refetch both v1 and v2 delegations to reflect the latest state
+        refetchV1Delegations();
+        refetchV2Delegations();
       }
       setProcessing(false);
     } catch (error: any) {
@@ -104,6 +109,8 @@ export function useRegistrationService() {
     showError,
     selectedDelegation,
     addDelegation,
+    refetchV1Delegations,
+    refetchV2Delegations,
   ]);
 
   return { registerPhase1Delegation };

--- a/src/app/state/DelegationState.tsx
+++ b/src/app/state/DelegationState.tsx
@@ -40,6 +40,7 @@ interface DelegationState {
   setProcessing: (value: boolean) => void;
   setSelectedDelegation: (delegation?: Delegation) => void;
   resetRegistration: () => void;
+  refetch: () => void;
 }
 
 const { StateProvider, useState: useDelegationState } =
@@ -56,11 +57,12 @@ const { StateProvider, useState: useDelegationState } =
     setProcessing: () => null,
     setSelectedDelegation: () => null,
     resetRegistration: () => null,
+    refetch: () => null,
   });
 
 export function DelegationState({ children }: PropsWithChildren) {
   const { publicKeyNoCoord } = useBTCWallet();
-  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
+  const { data, fetchNextPage, isFetchingNextPage, hasNextPage, refetch } =
     useDelegations();
 
   // States
@@ -130,6 +132,7 @@ export function DelegationState({ children }: PropsWithChildren) {
       setProcessing,
       setSelectedDelegation,
       resetRegistration,
+      refetch,
     }),
     [
       delegations,
@@ -144,6 +147,7 @@ export function DelegationState({ children }: PropsWithChildren) {
       setProcessing,
       setSelectedDelegation,
       resetRegistration,
+      refetch,
     ],
   );
 

--- a/src/app/state/DelegationV2State.tsx
+++ b/src/app/state/DelegationV2State.tsx
@@ -21,6 +21,7 @@ interface DelegationV2State {
   fetchMoreDelegations: () => void;
   findDelegationByTxHash: (txHash: string) => DelegationV2 | undefined;
   getStakedBalance: () => number;
+  refetch: () => void;
 }
 
 const STAKED_BALANCE_STATUSES = [
@@ -45,11 +46,12 @@ const { StateProvider, useState } = createStateUtils<DelegationV2State>({
   fetchMoreDelegations: () => {},
   findDelegationByTxHash: () => undefined,
   getStakedBalance: () => 0,
+  refetch: () => {},
 });
 
 export function DelegationV2State({ children }: PropsWithChildren) {
   const { publicKeyNoCoord } = useBTCWallet();
-  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
+  const { data, fetchNextPage, isFetchingNextPage, hasNextPage, refetch } =
     useDelegationsV2();
 
   // States
@@ -101,6 +103,7 @@ export function DelegationV2State({ children }: PropsWithChildren) {
       findDelegationByTxHash,
       fetchMoreDelegations: fetchNextPage,
       getStakedBalance,
+      refetch,
     }),
     [
       delegations,
@@ -111,6 +114,7 @@ export function DelegationV2State({ children }: PropsWithChildren) {
       findDelegationByTxHash,
       fetchNextPage,
       getStakedBalance,
+      refetch,
     ],
   );
 


### PR DESCRIPTION
This is to fix the issue where we already registered the delegation to phase-2, but still showing as active in phase-1. 
The API already updated the state to something transitioned when it show up in phase-2. So by refetching the API, we essentially will hide the phase-1 old delegation