### PR TITLE
fix: typos in function names (warning and parameters)

### DIFF
--- a/src/app/hooks/useNotification.tsx
+++ b/src/app/hooks/useNotification.tsx
@@ -9,7 +9,7 @@ export const notifySuccess = (title: string, text: string) => {
   toast.success(<Notification title={title} text={text} reactIcon={FaCheck} />);
 };
 
-export const notifyWraning = (title: string, text: string) => {
+export const notifyWarning = (title: string, text: string) => {
   toast.warning(
     <Notification title={title} text={text} reactIcon={PiWarningCircleBold} />,
   );

--- a/src/utils/isStakingSignReady.ts
+++ b/src/utils/isStakingSignReady.ts
@@ -19,11 +19,11 @@ export const isStakingSignReady = (
     };
 
   // Amount parameters are ready
-  const amountParamatersReady = minAmount && maxAmount;
+  const amountParametersReady = minAmount && maxAmount;
   // App values are filled
   const amountValuesReady = amount >= minAmount && amount <= maxAmount;
   // Amount is ready
-  const amountIsReady = amountParamatersReady && amountValuesReady;
+  const amountIsReady = amountParametersReady && amountValuesReady;
 
   // Time parameters are ready
   const timeParametersReady = minTime && maxTime;


### PR DESCRIPTION
Fix typos in function names

- Renamed `notifyWraning` to `notifyWarning` in useNotification.tsx
- Fixed parameter name from `amountParamatersReady` to `amountParametersReady` in isStakingSignReady.ts
