### PR TITLE
feat: Bump bbn-wallet-connect - unisat, leap, okx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "0.0.3-canary.5",
         "@babylonlabs-io/bbn-core-ui": "0.6.10",
-        "@babylonlabs-io/bbn-wallet-connect": "0.1.35",
+        "@babylonlabs-io/bbn-wallet-connect": "0.1.40",
         "@babylonlabs-io/btc-staking-ts": "0.4.0-canary.7",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
         "@bitcoinerlab/secp256k1": "^1.1.1",
@@ -1980,11 +1980,10 @@
       }
     },
     "node_modules/@babylonlabs-io/bbn-wallet-connect": {
-      "version": "0.1.35",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/bbn-wallet-connect/-/bbn-wallet-connect-0.1.35.tgz",
-      "integrity": "sha512-ya3otUkhqCGyHfT7hra2V1JVsgxQeGobbCyjOaAQ8VzafOAYuSxbkFZce3EHUh4jkTeK+ZV88oUnAnTWSqgeuw==",
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/bbn-wallet-connect/-/bbn-wallet-connect-0.1.40.tgz",
+      "integrity": "sha512-59Rk1tXdjv41+Fc+CPW4OJMW+A9Y7tVtN9DAaTZf02SRXfba/GhyGCHTcIJ3kS+9NIgTEzycJsainxc8aOsA7g==",
       "dependencies": {
-        "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/types": "^0.12.156",
         "@keystonehq/animated-qr": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babylonlabs-io/babylon-proto-ts": "0.0.3-canary.5",
     "@babylonlabs-io/bbn-core-ui": "0.6.10",
-    "@babylonlabs-io/bbn-wallet-connect": "0.1.35",
+    "@babylonlabs-io/bbn-wallet-connect": "0.1.40",
     "@babylonlabs-io/btc-staking-ts": "0.4.0-canary.7",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@bitcoinerlab/secp256k1": "^1.1.1",


### PR DESCRIPTION
Bumps `bbn-wallet-connect` library version
Includes new wallets

- Bitcoin - Unisat
- Babylon - Leap
- Babylon - OKX