### PR TITLE
improve inscription safety messaging for better clarity

### DIFF
--- a/src/app/components/Wallet/Connect.tsx
+++ b/src/app/components/Wallet/Connect.tsx
@@ -136,7 +136,7 @@ export const Connect: React.FC<ConnectProps> = ({
       </div>
       <div className="flex flex-row items-center justify-between">
         <Text variant="body2" className="text-sm text-primary-main">
-          {ordinalsExcluded ? "Not using Inscriptions" : "Using Inscriptions"}
+          {ordinalsExcluded ? "Inscription Safety: Enabled" : "Inscription Safety: Disabled"}
         </Text>
         <div className="flex flex-col items-center justify-center">
           <Toggle


### PR DESCRIPTION
> downstream team testing and building on top of Babylon.

Anyway, this messaging could use better clarity.

```diff
- {ordinalsExcluded ? "Not using Inscriptions" : "Using Inscriptions"}
+ {ordinalsExcluded ? "Inscription Safety: Enabled" : "Inscription Safety: Disabled"}
```

It caught me off guard, and I immediately thought, "Not using Inscriptions" Protection?
But really, it means "Not using (my) Inscriptions". I think a better alternative is "Inscription Safety: Enabled" since you can't guarantee but can enable safety.
