### PR TITLE
add missing sentry config to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ COPY next.config.mjs .
 COPY tsconfig.json .
 COPY tailwind.config.ts .
 COPY postcss.config.js .
+COPY sentry.client.config.ts .
 
 ARG NEXT_PUBLIC_MEMPOOL_API
 ENV NEXT_PUBLIC_MEMPOOL_API=${NEXT_PUBLIC_MEMPOOL_API}


### PR DESCRIPTION
This might be the reason why it didn't fire anything in https://btcstaking.phase-2-devnet.babylonlabs.io/