### PR TITLE
chore: Bump wallet connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@babylonlabs-io/babylon-proto-ts": "0.0.3-canary.5",
         "@babylonlabs-io/btc-staking-ts": "0.4.0-canary.15",
         "@babylonlabs-io/core-ui": "0.11.0",
-        "@babylonlabs-io/wallet-connector": "0.5.2",
+        "@babylonlabs-io/wallet-connector": "0.5.4",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@cosmjs/proto-signing": "^0.32.4",
@@ -2006,9 +2006,9 @@
       }
     },
     "node_modules/@babylonlabs-io/wallet-connector": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-0.5.2.tgz",
-      "integrity": "sha512-PfeXRzgBvWzdILbmpOtN7tp11QZsiaTHa3Vv0ObqWNDzgfDmJBREPpI/LdWoLFXttVQolhUVRoPsuhkUGJFJIQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-0.5.4.tgz",
+      "integrity": "sha512-Zk/dugNzrXNq95j1Y0fPY8gDmjjAFkmLtQPeUtfgiBpnr9UspBAoFr0FoQEvbkpPMNpOI9pr02njATWdWkKikw==",
       "dependencies": {
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/types": "^0.12.156",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babylonlabs-io/babylon-proto-ts": "0.0.3-canary.5",
     "@babylonlabs-io/core-ui": "0.11.0",
-    "@babylonlabs-io/wallet-connector": "0.5.2",
+    "@babylonlabs-io/wallet-connector": "0.5.4",
     "@babylonlabs-io/btc-staking-ts": "0.4.0-canary.15",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@bitcoinerlab/secp256k1": "^1.1.1",


### PR DESCRIPTION
Bumps wallet connector:
- `Keystone` to support `bip322-simple`
- Readme updated, states that Bitcoin only support `Native SegWit` and `Taproot`

@0xDazzer since `0.5.3` has `b5e6452: add persistent option`, are we ready to merge this? or should we wait for https://github.com/babylonlabs-io/simple-staking/pull/727 resolution?