### PR TITLE
feat: Keplr override modal error

### DIFF
--- a/src/app/context/wallet/WalletConnectionProvider.tsx
+++ b/src/app/context/wallet/WalletConnectionProvider.tsx
@@ -10,6 +10,7 @@ import { logTermsAcceptance } from "@/app/api/logTermAcceptance";
 import { verifyBTCAddress } from "@/app/api/verifyBTCAddress";
 import { TomoConnectionProvider } from "@/app/context/tomo/TomoProvider";
 import { TomoWidget } from "@/app/context/tomo/TomoWidget";
+import { ErrorType } from "@/app/types/errors";
 import { getNetworkConfigBBN } from "@/config/network/bbn";
 import { getNetworkConfigBTC } from "@/config/network/btc";
 
@@ -51,9 +52,19 @@ export const WalletConnectionProvider = ({ children }: PropsWithChildren) => {
   const { handleError } = useError();
 
   const onError = (error: Error) => {
-    handleError({
-      error,
-    });
+    if (error.message === "Keplr override") {
+      handleError({
+        error: {
+          message:
+            "Please disable other Cosmos extensions as they may interfere with Keplr.",
+          type: ErrorType.WALLET,
+        },
+      });
+    } else {
+      handleError({
+        error,
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
In case of `Keplr` override we will throw an error in `connectWallet()`

Current result: https://i.imgur.com/gnCOVsf.png

Things I don't like - initially in the design we had a different error modal. So we either match it, or keep our `ErrorModal` usage. Right now `handleError` usage is pretty simple in each of the screen, so we might do a different / more complicated UI approach for this particular use case. @0xDazzer @jonybur wdyt?

Related PR from `wallet-connector` side: https://github.com/babylonlabs-io/wallet-connector/pull/268
Related issue: https://github.com/babylonlabs-io/wallet-connector/issues/232

