### PR TITLE
fix: address screening error

### DIFF
--- a/src/app/api/logTermAcceptance.ts
+++ b/src/app/api/logTermAcceptance.ts
@@ -14,15 +14,17 @@ export const logTermsAcceptance = async ({
   address,
   public_key,
 }: TermsPayload) => {
-  const payload: TermsPayload = {
-    address: address,
-    public_key: encode(getPublicKeyNoCoord(public_key).toString("hex")),
-  };
+  try {
+    const payload: TermsPayload = {
+      address: address,
+      public_key: encode(getPublicKeyNoCoord(public_key).toString("hex")),
+    };
 
-  const response = await apiWrapper<unknown>(
-    "POST",
-    "/log-terms-acceptance",
-    "Error submitting terms acceptance request",
-    { body: payload },
-  );
+    await apiWrapper<unknown>(
+      "POST",
+      "/log-terms-acceptance",
+      "Error submitting terms acceptance request",
+      { body: payload },
+    );
+  } catch {}
 };

--- a/src/app/api/verifyBTCAddress.ts
+++ b/src/app/api/verifyBTCAddress.ts
@@ -1,5 +1,3 @@
-import { ERROR_SOURCES } from "../context/Error/ErrorProvider";
-
 import { apiWrapper } from "./apiWrapper";
 
 interface TermsPayload {
@@ -28,15 +26,7 @@ export const verifyBTCAddress = async (address: string) => {
 
     const risk = response.data?.btc_address?.risk;
     return risk ? ALLOWED_STATUSES.includes(risk.toLowerCase()) : false;
-  } catch (error) {
-    if (error && typeof error === "object") {
-      const serverError = error as any;
-      if (!serverError.metadata) serverError.metadata = {};
-      serverError.metadata.errorSource = ERROR_SOURCES.ADDRESS_SCREENING;
-
-      if (serverError.message)
-        serverError.message = `Address screening error: ${serverError.message}`;
-    }
-    throw error;
+  } catch {
+    return false;
   }
 };

--- a/src/app/context/Error/ErrorProvider.tsx
+++ b/src/app/context/Error/ErrorProvider.tsx
@@ -20,12 +20,11 @@ import { ClientError, ServerError } from "./errors";
 // Error source identifiers
 export const ERROR_SOURCES = {
   ORDINALS: "ORDINALS_ERROR",
-  ADDRESS_SCREENING: "ADDRESS_SCREENING_ERROR",
 };
 
 // Configuration for errors that shouldn't show a modal by default
 const SILENT_ERROR_CONFIG = {
-  sources: [ERROR_SOURCES.ORDINALS, ERROR_SOURCES.ADDRESS_SCREENING],
+  sources: [ERROR_SOURCES.ORDINALS],
 };
 
 const ErrorContext = createContext<ErrorContextType>({


### PR DESCRIPTION
Okay, I did a dirty trick. We don't throw an error for address screening and don't delegate it to simple staking. Instead we simple display our default error modal which is generic enough

### Before:
![image](https://github.com/user-attachments/assets/8001f44c-fbcf-42f0-83c1-7df96a5b7154)

### After:
<img width="780" alt="Screenshot 2025-03-27 at 17 46 43" src="https://github.com/user-attachments/assets/d17ff24f-ec30-40ab-8d17-5003233e0358" />
