### PR TITLE
feat: adds URL validation

### DIFF
--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -10,6 +10,35 @@ type FetchOptions = {
 };
 
 /**
+ * Validates a URL path component to prevent path traversal attacks
+ * @param path - The path component to validate
+ * @returns The validated path component
+ * @throws ServerError if the path contains potentially malicious sequences
+ */
+export const validateUrlPath = (path: string): string => {
+  const pathTraversalPatterns = [
+    /\.\./, // Double dot
+    /\.\/|\/\./, // Current directory references
+    /\/|\\/, // Forward and back slashes
+    /%2e%2e/i, // URL encoded '..'
+    /%2e\//i,
+    /\/%2e/i, // URL encoded './'
+    /%2f/i,
+    /%5c/i, // URL encoded '/' and '\'
+  ];
+
+  if (pathTraversalPatterns.some((pattern) => pattern.test(path))) {
+    throw new ServerError({
+      message: "Invalid parameter: potential path traversal detected",
+      status: HttpStatusCode.BadRequest,
+      endpoint: "validateUrlPath",
+    });
+  }
+
+  return path;
+};
+
+/**
  * Wrapper for fetch with standardized error handling and response parsing
  * @param url - The URL to fetch from
  * @param options - Fetch options for API requests

--- a/src/utils/mempool_api.ts
+++ b/src/utils/mempool_api.ts
@@ -5,7 +5,7 @@ import { API_ENDPOINTS } from "@/app/constants/endpoints";
 import { ServerError } from "@/app/context/Error/errors";
 import { Fees } from "@/app/types/fee";
 import { getNetworkConfigBTC } from "@/config/network/btc";
-import { fetchApi } from "@/utils/fetch";
+import { fetchApi, validateUrlPath } from "@/utils/fetch";
 
 const { mempoolApiUrl } = getNetworkConfigBTC();
 
@@ -63,7 +63,7 @@ const mempoolAPI = `${mempoolApiUrl}/api/`;
 
 // URL for the address info endpoint
 function addressInfoUrl(address: string): URL {
-  return new URL(mempoolAPI + "address/" + address);
+  return new URL(mempoolAPI + "address/" + validateUrlPath(address));
 }
 
 // URL for the push transaction endpoint
@@ -73,7 +73,7 @@ function pushTxUrl(): URL {
 
 // URL for retrieving information about an address' UTXOs
 function utxosInfoUrl(address: string): URL {
-  return new URL(mempoolAPI + "address/" + address + "/utxo");
+  return new URL(mempoolAPI + "address/" + validateUrlPath(address) + "/utxo");
 }
 
 // URL for retrieving information about the recommended network fees
@@ -89,12 +89,16 @@ function btcTipHeightUrl(): URL {
 // URL for validating an address which contains a set of information about the address
 // including the scriptPubKey
 function validateAddressUrl(address: string): URL {
-  return new URL(mempoolAPI + "v1/validate-address/" + address);
+  return new URL(
+    mempoolAPI + "v1/validate-address/" + validateUrlPath(address),
+  );
 }
 
 // URL for the transaction info endpoint
 function txInfoUrl(txId: string): URL {
-  return new URL(mempoolAPI + API_ENDPOINTS.MEMPOOL.TX + "/" + txId);
+  return new URL(
+    mempoolAPI + API_ENDPOINTS.MEMPOOL.TX + "/" + validateUrlPath(txId),
+  );
 }
 
 // URL for the transaction merkle proof endpoint
@@ -103,7 +107,7 @@ function txMerkleProofUrl(txId: string): URL {
     mempoolAPI +
       API_ENDPOINTS.MEMPOOL.TX +
       "/" +
-      txId +
+      validateUrlPath(txId) +
       "/" +
       API_ENDPOINTS.MEMPOOL.MERKLE_PROOF,
   );
@@ -111,7 +115,7 @@ function txMerkleProofUrl(txId: string): URL {
 
 // URL for the transaction hex endpoint
 function txHexUrl(txId: string): URL {
-  return new URL(mempoolAPI + "tx/" + txId + "/hex");
+  return new URL(mempoolAPI + "tx/" + validateUrlPath(txId) + "/hex");
 }
 
 /**

--- a/tests/utils/fetch.test.ts
+++ b/tests/utils/fetch.test.ts
@@ -1,0 +1,96 @@
+import { ServerError } from "@/app/context/Error/errors";
+import { validateUrlPath } from "@/utils/fetch";
+
+describe("validateUrlPath", () => {
+  describe("Valid inputs", () => {
+    it("should accept regular alphanumeric strings", () => {
+      expect(() => validateUrlPath("abc123")).not.toThrow();
+    });
+
+    it("should accept Bitcoin addresses", () => {
+      expect(() =>
+        validateUrlPath("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"),
+      ).not.toThrow();
+    });
+
+    it("should accept transaction IDs", () => {
+      expect(() =>
+        validateUrlPath(
+          "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+        ),
+      ).not.toThrow();
+    });
+
+    it("should accept strings with single dots", () => {
+      expect(() => validateUrlPath("abc.def")).not.toThrow();
+    });
+
+    it("should accept strings with hyphens and underscores", () => {
+      expect(() => validateUrlPath("abc-def_ghi")).not.toThrow();
+    });
+  });
+
+  describe("Path traversal attacks", () => {
+    it("should reject double dots", () => {
+      expect(() => validateUrlPath("..")).toThrow(ServerError);
+      expect(() => validateUrlPath("abc..def")).toThrow(ServerError);
+    });
+
+    it("should reject forward slashes", () => {
+      expect(() => validateUrlPath("abc/def")).toThrow(ServerError);
+    });
+
+    it("should reject backslashes", () => {
+      expect(() => validateUrlPath("abc\\def")).toThrow(ServerError);
+    });
+
+    it("should reject current directory references", () => {
+      expect(() => validateUrlPath("./abc")).toThrow(ServerError);
+      expect(() => validateUrlPath("abc/.")).toThrow(ServerError);
+    });
+
+    it("should reject parent directory traversal", () => {
+      expect(() => validateUrlPath("../abc")).toThrow(ServerError);
+      expect(() => validateUrlPath("abc/..")).toThrow(ServerError);
+      expect(() => validateUrlPath("abc/../def")).toThrow(ServerError);
+    });
+
+    it("should reject URL encoded path traversal attempts", () => {
+      // URL encoded '..'
+      expect(() => validateUrlPath("%2e%2e")).toThrow(ServerError);
+      expect(() => validateUrlPath("%2E%2E")).toThrow(ServerError);
+
+      // URL encoded '/'
+      expect(() => validateUrlPath("abc%2fdef")).toThrow(ServerError);
+      expect(() => validateUrlPath("abc%2Fdef")).toThrow(ServerError);
+
+      // URL encoded '\'
+      expect(() => validateUrlPath("abc%5cdef")).toThrow(ServerError);
+      expect(() => validateUrlPath("abc%5Cdef")).toThrow(ServerError);
+
+      // URL encoded './'
+      expect(() => validateUrlPath("%2e%2f")).toThrow(ServerError);
+      expect(() => validateUrlPath("%2E%2F")).toThrow(ServerError);
+    });
+
+    it("should reject mixed encoded/non-encoded path traversal attempts", () => {
+      expect(() => validateUrlPath("..%2fdef")).toThrow(ServerError);
+      expect(() => validateUrlPath("%2e./def")).toThrow(ServerError);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty strings", () => {
+      expect(() => validateUrlPath("")).not.toThrow();
+    });
+
+    it("should accept strings with special characters that aren't path traversal related", () => {
+      expect(() => validateUrlPath("abc!@#$%^&*()def")).not.toThrow();
+    });
+
+    it("should handle very long strings", () => {
+      const longString = "a".repeat(1000);
+      expect(() => validateUrlPath(longString)).not.toThrow();
+    });
+  });
+});

--- a/tests/utils/mempool_api.test.ts
+++ b/tests/utils/mempool_api.test.ts
@@ -1,0 +1,172 @@
+import { ServerError } from "@/app/context/Error/errors";
+import { getNetworkConfigBTC } from "@/config/network/btc";
+import * as fetchModule from "@/utils/fetch";
+import * as mempoolApiModule from "@/utils/mempool_api";
+
+const { mempoolApiUrl } = getNetworkConfigBTC();
+
+jest.mock("@/utils/fetch", () => {
+  const originalModule = jest.requireActual("@/utils/fetch");
+  return {
+    ...originalModule,
+    validateUrlPath: jest.fn((path) => {
+      try {
+        return originalModule.validateUrlPath(path);
+      } catch (error) {
+        throw error;
+      }
+    }),
+    fetchApi: jest.fn().mockImplementation(() => Promise.resolve({})),
+  };
+});
+
+describe("mempool_api URL construction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Integration with validateUrlPath", () => {
+    it("should validate address in getAddressBalance", async () => {
+      const mockAddress = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+      (fetchModule.fetchApi as jest.Mock).mockResolvedValueOnce({
+        chain_stats: {
+          funded_txo_sum: 100,
+          spent_txo_sum: 50,
+        },
+      });
+
+      await mempoolApiModule.getAddressBalance(mockAddress);
+
+      expect(fetchModule.validateUrlPath).toHaveBeenCalledWith(mockAddress);
+    });
+
+    it("should validate address in getUTXOs", async () => {
+      const mockAddress = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+      (fetchModule.fetchApi as jest.Mock).mockResolvedValueOnce([
+        {
+          txid: "abc123",
+          vout: 0,
+          value: 100,
+          status: { confirmed: true },
+        },
+      ]);
+
+      (fetchModule.fetchApi as jest.Mock).mockResolvedValueOnce({
+        isvalid: true,
+        scriptPubKey: "script123",
+      });
+
+      await mempoolApiModule.getUTXOs(mockAddress);
+
+      expect(fetchModule.validateUrlPath).toHaveBeenCalledWith(mockAddress);
+      expect(fetchModule.validateUrlPath).toHaveBeenCalledTimes(2);
+    });
+
+    it("should validate transaction ID in getTxInfo", async () => {
+      const mockTxId =
+        "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d";
+
+      (fetchModule.fetchApi as jest.Mock).mockResolvedValueOnce({
+        txid: mockTxId,
+        version: 1,
+        locktime: 0,
+        vin: [],
+        vout: [],
+        size: 100,
+        weight: 400,
+        fee: 10,
+        status: {
+          confirmed: true,
+          block_height: 100,
+          block_hash: "hash123",
+          block_time: 123456789,
+        },
+      });
+
+      await mempoolApiModule.getTxInfo(mockTxId);
+
+      expect(fetchModule.validateUrlPath).toHaveBeenCalledWith(mockTxId);
+    });
+
+    it("should validate transaction ID in getTxMerkleProof", async () => {
+      const mockTxId =
+        "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d";
+
+      (fetchModule.fetchApi as jest.Mock).mockResolvedValueOnce({
+        block_height: 100,
+        merkle: ["hash1", "hash2"],
+        pos: 1,
+      });
+
+      await mempoolApiModule.getTxMerkleProof(mockTxId);
+
+      expect(fetchModule.validateUrlPath).toHaveBeenCalledWith(mockTxId);
+    });
+
+    it("should validate transaction ID in getTxHex", async () => {
+      const mockTxId =
+        "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d";
+
+      (fetchModule.fetchApi as jest.Mock).mockResolvedValueOnce(
+        "0123456789abcdef",
+      );
+
+      await mempoolApiModule.getTxHex(mockTxId);
+
+      expect(fetchModule.validateUrlPath).toHaveBeenCalledWith(mockTxId);
+    });
+  });
+
+  describe("Handling invalid inputs", () => {
+    it("should throw ServerError for path traversal in address", async () => {
+      const maliciousAddress = "../etc/passwd";
+
+      // Mock validateUrlPath to throw error as it would with this input
+      (fetchModule.validateUrlPath as jest.Mock).mockImplementationOnce(() => {
+        throw new ServerError({
+          message: "Invalid parameter: potential path traversal detected",
+          status: 400,
+          endpoint: "validateUrlPath",
+        });
+      });
+
+      await expect(
+        mempoolApiModule.getAddressBalance(maliciousAddress),
+      ).rejects.toThrow(ServerError);
+    });
+
+    it("should throw ServerError for path traversal in transaction ID", async () => {
+      const maliciousTxId = "abc/../def";
+
+      (fetchModule.validateUrlPath as jest.Mock).mockImplementationOnce(() => {
+        throw new ServerError({
+          message: "Invalid parameter: potential path traversal detected",
+          status: 400,
+          endpoint: "validateUrlPath",
+        });
+      });
+
+      await expect(mempoolApiModule.getTxInfo(maliciousTxId)).rejects.toThrow(
+        ServerError,
+      );
+    });
+
+    it("should throw ServerError for URL encoded path traversal in address", async () => {
+      const maliciousAddress = "abc%2e%2edef";
+
+      (fetchModule.validateUrlPath as jest.Mock).mockImplementationOnce(() => {
+        throw new ServerError({
+          message: "Invalid parameter: potential path traversal detected",
+          status: 400,
+          endpoint: "validateUrlPath",
+        });
+      });
+
+      await expect(
+        mempoolApiModule.getAddressBalance(maliciousAddress),
+      ).rejects.toThrow(ServerError);
+    });
+  });
+});


### PR DESCRIPTION
Added path traversal protection to API client to prevent potential security vulnerabilities by validating URL path components before making requests.

This prevents attackers from accessing unintended resources by using malicious inputs like `../config` or encoded variants like `%2e%2e%2fconfig`. Without these checks, user-provided addresses or transaction IDs containing path traversal sequences could potentially access unauthorized API endpoints.

Implementation includes test coverage to verify both the validation logic and integration with the mempool_api functions.

https://github.com/babylonlabs-io/simple-staking/issues/693