### PR TITLE
fix: set up polling after claiming rewards

### DIFF
--- a/src/app/components/PersonalBalance/PersonalBalance.tsx
+++ b/src/app/components/PersonalBalance/PersonalBalance.tsx
@@ -75,10 +75,10 @@ export function PersonalBalance() {
           />
 
           <StatItem
-            loading={isBalanceLoading}
+            loading={isBalanceLoading || processing}
             title={`${isMobile ? "BABY" : bbnNetworkName} Balance`}
             value={
-              isBalanceLoading
+              isBalanceLoading || processing
                 ? ""
                 : `${ubbnToBaby(bbnBalance)} ${bbnCoinSymbol}`
             }

--- a/src/app/hooks/services/useRewardsService.ts
+++ b/src/app/hooks/services/useRewardsService.ts
@@ -58,28 +58,6 @@ export const useRewardsService = () => {
       await sendBbnTx(signedTx);
 
       await refetchRewardBalance();
-
-      const initialBalance = balanceQuery.data || 0;
-      let attempts = 0;
-      const maxAttempts = 10;
-      const pollInterval = 2e3;
-
-      const pollBalance = async () => {
-        if (attempts >= maxAttempts) {
-          return;
-        }
-
-        attempts++;
-        await balanceQuery.refetch();
-
-        if (balanceQuery.data !== initialBalance) {
-          return;
-        }
-
-        setTimeout(pollBalance, pollInterval);
-      };
-
-      await pollBalance();
     } catch (error) {
       console.error("Error claiming rewards:", error);
     } finally {
@@ -90,7 +68,6 @@ export const useRewardsService = () => {
     signBbnTx,
     sendBbnTx,
     refetchRewardBalance,
-    balanceQuery,
     setProcessing,
     closeRewardModal,
   ]);

--- a/src/app/hooks/services/useRewardsService.ts
+++ b/src/app/hooks/services/useRewardsService.ts
@@ -9,8 +9,8 @@ import { BBN_REGISTRY_TYPE_URLS } from "@/utils/wallet/bbnRegistry";
 import { useBbnTransaction } from "../client/rpc/mutation/useBbnTransaction";
 import { useBbnQuery } from "../client/rpc/queries/useBbnQuery";
 
-const MAX_RETRY_ATTEMPTS = 10;
-const POLL_INTERVAL = 2000;
+const MAX_RETRY_ATTEMPTS = 3;
+const POLL_INTERVAL = 10e3;
 
 export const useRewardsService = () => {
   const {

--- a/src/app/hooks/services/useRewardsService.ts
+++ b/src/app/hooks/services/useRewardsService.ts
@@ -58,6 +58,28 @@ export const useRewardsService = () => {
       await sendBbnTx(signedTx);
 
       await refetchRewardBalance();
+
+      const initialBalance = balanceQuery.data || 0;
+      let attempts = 0;
+      const maxAttempts = 10;
+      const pollInterval = 2e3;
+
+      const pollBalance = async () => {
+        if (attempts >= maxAttempts) {
+          return;
+        }
+
+        attempts++;
+        await balanceQuery.refetch();
+
+        if (balanceQuery.data !== initialBalance) {
+          return;
+        }
+
+        setTimeout(pollBalance, pollInterval);
+      };
+
+      await pollBalance();
     } catch (error) {
       console.error("Error claiming rewards:", error);
     } finally {
@@ -68,6 +90,7 @@ export const useRewardsService = () => {
     signBbnTx,
     sendBbnTx,
     refetchRewardBalance,
+    balanceQuery,
     setProcessing,
     closeRewardModal,
   ]);

--- a/src/app/hooks/services/useRewardsService.ts
+++ b/src/app/hooks/services/useRewardsService.ts
@@ -1,11 +1,11 @@
 import { incentivetx } from "@babylonlabs-io/babylon-proto-ts";
 import { useCallback } from "react";
 
+import { useError } from "@/app/context/Error/ErrorProvider";
 import { useRewardsState } from "@/app/state/RewardState";
 import { BBN_REGISTRY_TYPE_URLS } from "@/utils/wallet/bbnRegistry";
 
 import { useBbnTransaction } from "../client/rpc/mutation/useBbnTransaction";
-import { useBbnQuery } from "../client/rpc/queries/useBbnQuery";
 
 export const useRewardsService = () => {
   const {
@@ -16,9 +16,9 @@ export const useRewardsService = () => {
     setProcessing,
     setTransactionFee,
   } = useRewardsState();
-  const { balanceQuery } = useBbnQuery();
 
   const { estimateBbnGasFee, sendBbnTx, signBbnTx } = useBbnTransaction();
+  const { handleError } = useError();
 
   /**
    * Estimates the gas fee for claiming rewards.
@@ -58,8 +58,10 @@ export const useRewardsService = () => {
       await sendBbnTx(signedTx);
 
       await refetchRewardBalance();
-    } catch (error) {
-      console.error("Error claiming rewards:", error);
+    } catch (error: Error | any) {
+      handleError({
+        error,
+      });
     } finally {
       setProcessing(false);
     }
@@ -70,6 +72,7 @@ export const useRewardsService = () => {
     refetchRewardBalance,
     setProcessing,
     closeRewardModal,
+    handleError,
   ]);
 
   return {

--- a/src/app/hooks/services/useRewardsService.ts
+++ b/src/app/hooks/services/useRewardsService.ts
@@ -1,13 +1,16 @@
 import { incentivetx } from "@babylonlabs-io/babylon-proto-ts";
 import { useCallback } from "react";
 
+import { useError } from "@/app/context/Error/ErrorProvider";
 import { useRewardsState } from "@/app/state/RewardState";
 import { retry } from "@/utils";
 import { BBN_REGISTRY_TYPE_URLS } from "@/utils/wallet/bbnRegistry";
-import { useError } from "@/app/context/Error/ErrorProvider";
 
 import { useBbnTransaction } from "../client/rpc/mutation/useBbnTransaction";
 import { useBbnQuery } from "../client/rpc/queries/useBbnQuery";
+
+const MAX_RETRY_ATTEMPTS = 10;
+const POLL_INTERVAL = 2000;
 
 export const useRewardsService = () => {
   const {
@@ -68,8 +71,8 @@ export const useRewardsService = () => {
           return balanceQuery.data;
         },
         (value) => value !== initialBalance,
-        2000,
-        10,
+        POLL_INTERVAL,
+        MAX_RETRY_ATTEMPTS,
       );
     } catch (error: Error | any) {
       handleError({

--- a/src/app/hooks/services/useRewardsService.ts
+++ b/src/app/hooks/services/useRewardsService.ts
@@ -1,11 +1,11 @@
 import { incentivetx } from "@babylonlabs-io/babylon-proto-ts";
 import { useCallback } from "react";
 
-import { useError } from "@/app/context/Error/ErrorProvider";
 import { useRewardsState } from "@/app/state/RewardState";
 import { BBN_REGISTRY_TYPE_URLS } from "@/utils/wallet/bbnRegistry";
 
 import { useBbnTransaction } from "../client/rpc/mutation/useBbnTransaction";
+import { useBbnQuery } from "../client/rpc/queries/useBbnQuery";
 
 export const useRewardsService = () => {
   const {
@@ -16,9 +16,9 @@ export const useRewardsService = () => {
     setProcessing,
     setTransactionFee,
   } = useRewardsState();
+  const { balanceQuery } = useBbnQuery();
 
   const { estimateBbnGasFee, sendBbnTx, signBbnTx } = useBbnTransaction();
-  const { handleError } = useError();
 
   /**
    * Estimates the gas fee for claiming rewards.
@@ -58,10 +58,8 @@ export const useRewardsService = () => {
       await sendBbnTx(signedTx);
 
       await refetchRewardBalance();
-    } catch (error: Error | any) {
-      handleError({
-        error,
-      });
+    } catch (error) {
+      console.error("Error claiming rewards:", error);
     } finally {
       setProcessing(false);
     }
@@ -72,7 +70,6 @@ export const useRewardsService = () => {
     refetchRewardBalance,
     setProcessing,
     closeRewardModal,
-    handleError,
   ]);
 
   return {

--- a/src/app/state/RewardState.tsx
+++ b/src/app/state/RewardState.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
 
 import { useCosmosWallet } from "@/app/context/wallet/CosmosWalletProvider";
 import { useBbnQuery } from "@/app/hooks/client/rpc/queries/useBbnQuery";
-import { retry } from "@/utils";
 import { createStateUtils } from "@/utils/createStateUtils";
 
 interface RewardsStateProps {
@@ -47,9 +46,8 @@ export function RewardsState({ children }: PropsWithChildren) {
     rewardsQuery: {
       data: rewardBalance = 0,
       isLoading: isRewardBalanceLoading,
-      refetch: refetchRewards,
+      refetch: refetchRewardBalance,
     },
-    balanceQuery,
   } = useBbnQuery();
 
   const openRewardModal = useCallback(() => {
@@ -59,23 +57,6 @@ export function RewardsState({ children }: PropsWithChildren) {
   const closeRewardModal = useCallback(() => {
     setRewardModal(false);
   }, []);
-
-  const refetchRewardBalance = useCallback(async () => {
-    await refetchRewards();
-
-    if (balanceQuery) {
-      const initialBalance = balanceQuery.data || 0;
-
-      await retry(
-        () => {
-          return balanceQuery.refetch().then(() => balanceQuery.data || 0);
-        },
-        (currentBalance) => currentBalance !== initialBalance,
-        2e3, // 2 seconds polling interval
-        10, // Maximum 10 attempts
-      );
-    }
-  }, [refetchRewards, balanceQuery]);
 
   const context = useMemo(
     () => ({
@@ -89,7 +70,9 @@ export function RewardsState({ children }: PropsWithChildren) {
       setProcessing,
       openRewardModal,
       closeRewardModal,
-      refetchRewardBalance,
+      refetchRewardBalance: async () => {
+        await refetchRewardBalance();
+      },
     }),
     [
       isRewardBalanceLoading,


### PR DESCRIPTION
Resolves the issue where BABY Balance displays as zero immediately after claiming rewards. Implemented polling mechanism that checks for balance updates for up to 20 seconds after a successful claim transaction, providing a better user experience with accurate balance information.

https://github.com/user-attachments/assets/f5409436-80e6-4f50-b43c-464c783c1b78


