### PR TITLE
update sentry tag

### DIFF
--- a/src/app/context/Error/ErrorProvider.tsx
+++ b/src/app/context/Error/ErrorProvider.tsx
@@ -103,23 +103,26 @@ export const ErrorProvider: React.FC<ErrorProviderProps> = ({ children }) => {
 
       const eventId = Sentry.withScope((scope) => {
         if (error instanceof ServerError) {
+          scope.setTag("errorType", ErrorType.SERVER);
+          scope.setTag("status", error.status);
+          scope.setTag("endpoint", error.endpoint);
+
           scope.setExtras({
-            errorType: ErrorType.SERVER,
-            endpoint: error.endpoint,
-            status: error.status,
             trace: stackTrace,
             request: error.request || {},
             response: error.response || {},
             ...combinedMetadata,
           });
         } else if (error instanceof ClientError) {
+          scope.setTag("errorType", error.type ?? ErrorType.UNKNOWN);
+          scope.setTag("errorCategory", error.category);
+
           scope.setExtras({
-            errorCategory: error.category,
-            errorType: error.type ?? ErrorType.UNKNOWN,
             trace: stackTrace,
             ...combinedMetadata,
           });
         } else {
+          scope.setTag("errorType", ErrorType.UNKNOWN);
           scope.setExtras({
             trace: stackTrace,
             ...combinedMetadata,

--- a/tests/context/Error/ErrorProvider.test.tsx
+++ b/tests/context/Error/ErrorProvider.test.tsx
@@ -20,6 +20,7 @@ jest.mock("@sentry/nextjs", () => {
     withScope: mockSentryWithScope.mockImplementation((fn) => {
       const mockScope = {
         setExtras: jest.fn(),
+        setTag: jest.fn(),
       };
       fn(mockScope);
       return "mock-sentry-event-id";
@@ -99,18 +100,28 @@ describe("ErrorProvider", () => {
     expect(mockedSentry.captureException).toHaveBeenCalledWith(testError);
 
     const scopeFunction = mockedSentry.withScope.mock.calls[0][0];
-    const mockScope = { setExtras: jest.fn() };
+    const mockScope = {
+      setExtras: jest.fn(),
+      setTag: jest.fn(),
+    };
     scopeFunction(mockScope);
     const metadataPassedToSentry = mockScope.setExtras.mock.calls[0][0];
 
     expect(metadataPassedToSentry).toMatchObject({
-      errorCategory: ClientErrorCategory.CLIENT_TRANSACTION,
-      errorType: ErrorType.STAKING,
       userPublicKey: mockWalletData.userPublicKey,
       btcAddress: mockWalletData.btcAddress,
       babylonAddress: mockWalletData.babylonAddress,
       testField: "Additional test data",
     });
+
+    expect(mockScope.setTag).toHaveBeenCalledWith(
+      "errorType",
+      ErrorType.STAKING,
+    );
+    expect(mockScope.setTag).toHaveBeenCalledWith(
+      "errorCategory",
+      ClientErrorCategory.CLIENT_TRANSACTION,
+    );
   });
 
   it("handles error without wallet metadata", async () => {
@@ -134,13 +145,24 @@ describe("ErrorProvider", () => {
     expect(mockedSentry.captureException).toHaveBeenCalledWith(testError);
 
     const scopeFunction = mockedSentry.withScope.mock.calls[0][0];
-    const mockScope = { setExtras: jest.fn() };
+    const mockScope = {
+      setExtras: jest.fn(),
+      setTag: jest.fn(),
+    };
     scopeFunction(mockScope);
     const metadataPassedToSentry = mockScope.setExtras.mock.calls[0][0];
 
     expect(metadataPassedToSentry).toMatchObject({
-      errorCategory: ClientErrorCategory.CLIENT_UNKNOWN,
-      errorType: ErrorType.UNKNOWN,
+      errorSource: undefined,
     });
+
+    expect(mockScope.setTag).toHaveBeenCalledWith(
+      "errorType",
+      ErrorType.UNKNOWN,
+    );
+    expect(mockScope.setTag).toHaveBeenCalledWith(
+      "errorCategory",
+      ClientErrorCategory.CLIENT_UNKNOWN,
+    );
   });
 });


### PR DESCRIPTION
The error keys should be put tag instead of extras in order to do proper alerts and filtering