### PR TITLE
fix: use APR instead of APY from API

### DIFF
--- a/src/app/api/getSystemStats.ts
+++ b/src/app/api/getSystemStats.ts
@@ -10,7 +10,7 @@ export interface SystemStats {
   active_finality_providers: number;
   total_finality_providers: number;
   total_active_tvl: number;
-  btc_staking_apy: number;
+  btc_staking_apr: number;
 }
 
 interface SystemStatsAPIResponse {

--- a/src/app/components/Stats/Stats.tsx
+++ b/src/app/components/Stats/Stats.tsx
@@ -24,7 +24,7 @@ export const Stats = memo(() => {
       active_tvl: activeTVL = 0,
       total_finality_providers: totalFPs = 0,
       active_finality_providers: activeFPs = 0,
-      btc_staking_apy: stakingAPR,
+      btc_staking_apr: stakingAPR,
     } = {},
     isLoading,
   } = useSystemStats();


### PR DESCRIPTION
We had to change the term from APY to APR. 
The same change has now been applied in the backend API as well, so that we can completely remove the term APY in the codebase.