### PR TITLE
[WIP] - feat: Unisat contracts state flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@babylonlabs-io/babylon-proto-ts": "1.0.1",
         "@babylonlabs-io/btc-staking-ts": "1.0.6",
         "@babylonlabs-io/core-ui": "1.0.1",
-        "@babylonlabs-io/wallet-connector": "1.1.1",
+        "@babylonlabs-io/wallet-connector": "1.3.0",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@cosmjs/proto-signing": "^0.32.4",
@@ -2011,9 +2011,9 @@
       }
     },
     "node_modules/@babylonlabs-io/wallet-connector": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.1.1.tgz",
-      "integrity": "sha512-AcvEucktUI3VHu/vfLD1htatSlL33bMJWjdUCkLr6WzSpDhp0GRbeNDj9lQSBl9CYfuEjZixvofTXK4ucvX5Jw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.3.0.tgz",
+      "integrity": "sha512-FVnSyiPBe4lh4ljF5fmYhls4RQ5DD18dO6tgN/3PfvsevMOzoNsbkBCmP+D/B4HLCVvOrE6F4lOgEIkY37E3ew==",
       "dependencies": {
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/provider-extension": "^0.12.204",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babylonlabs-io/babylon-proto-ts": "1.0.1",
     "@babylonlabs-io/btc-staking-ts": "1.0.6",
     "@babylonlabs-io/core-ui": "1.0.1",
-    "@babylonlabs-io/wallet-connector": "1.1.1",
+    "@babylonlabs-io/wallet-connector": "1.3.0",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@bitcoinerlab/secp256k1": "^1.1.1",
     "@cosmjs/proto-signing": "^0.32.4",

--- a/src/app/components/Modals/SignModal/SignModal.tsx
+++ b/src/app/components/Modals/SignModal/SignModal.tsx
@@ -6,10 +6,14 @@ import {
   Loader,
   Text,
 } from "@babylonlabs-io/core-ui";
+import { useMemo } from "react";
 
 import { ResponsiveDialog } from "@/app/components/Modals/ResponsiveDialog";
+import { useCosmosWallet } from "@/app/context/wallet/CosmosWalletProvider";
+import { useComposedSignOptionsData } from "@/app/hooks/useComposedSignOptions";
 import { getNetworkConfigBBN } from "@/config/network/bbn";
 import { getNetworkConfigBTC } from "@/config/network/btc";
+import { satoshiToBtc } from "@/utils/btc";
 
 import { Step } from "./Step";
 
@@ -32,62 +36,171 @@ export const SignModal = ({
   step,
   onClose,
   onSubmit,
-}: SignModalProps) => (
-  <ResponsiveDialog open={open} onClose={onClose} hasBackdrop>
-    <DialogHeader
-      title={title}
-      onClose={onClose}
-      className="text-accent-primary"
-    />
+}: SignModalProps) => {
+  const { getSignPsbtOptions } = useComposedSignOptionsData();
+  const { bech32Address } = useCosmosWallet();
 
-    <DialogBody className="flex flex-col pb-8 pt-4 text-accent-primary gap-4">
-      <Text variant="body1" className="text-accent-secondary">
-        Please sign the following messages
-      </Text>
+  // Generate step details based on transaction data
+  const getStepDetails = useMemo(() => {
+    // Helper to format or provide default for undefined values
+    const formatValue = (value: any, formatter?: (v: any) => string) => {
+      if (value === undefined || value === null) return "-";
+      return formatter ? formatter(value) : value.toString();
+    };
 
-      <div className="py-4 flex flex-col items-start gap-6">
-        <Step step={1} currentStep={step}>
-          Consent to slashing
-        </Step>
-        <Step step={2} currentStep={step}>
-          Consent to slashing during unbonding
-        </Step>
-        <Step step={3} currentStep={step}>
-          {coinSymbol}-{bbnCoinSymbol} address binding for receiving staking
-          rewards
-        </Step>
-        <Step step={4} currentStep={step}>
-          Staking transaction registration
-        </Step>
-      </div>
-    </DialogBody>
+    // Format number with commas
+    const formatNumber = (num: number) => new Intl.NumberFormat().format(num);
 
-    <DialogFooter className="flex gap-4">
-      {onClose && (
-        <Button
-          variant="outlined"
-          color="primary"
-          onClick={onClose}
-          className="flex-1 text-xs sm:text-base"
-        >
-          Cancel
-        </Button>
-      )}
+    // Format BTC amount properly
+    const formatBtcAmount = (sats: number) =>
+      `${satoshiToBtc(sats)} ${coinSymbol}`;
 
-      {onSubmit && (
-        <Button
-          disabled={processing}
-          variant="contained"
-          className="flex-1 text-xs sm:text-base"
-          onClick={onSubmit}
-        >
-          {processing ? (
-            <Loader size={16} className="text-accent-contrast" />
-          ) : (
-            "Sign"
-          )}
-        </Button>
-      )}
-    </DialogFooter>
-  </ResponsiveDialog>
-);
+    // Format public key (truncate)
+    const formatPK = (pk: string) =>
+      pk.length > 16
+        ? `${pk.substring(0, 8)}...${pk.substring(pk.length - 8)}`
+        : pk;
+
+    // Format block count as time
+    const formatBlocks = (blocks: number) => `${formatNumber(blocks)} blocks`;
+
+    const data = getSignPsbtOptions();
+
+    const signPsbtOptions =
+      data.contracts && data.contracts.length > 0 && data.contracts[0].params
+        ? data.contracts[0].params
+        : {};
+
+    return {
+      // Step 1: Consent to slashing
+      getStep1Details: () => ({
+        "Finality Provider": formatValue(
+          signPsbtOptions.finalityProviderPK,
+          formatPK,
+        ),
+        "Staking Amount": formatValue(
+          signPsbtOptions.stakingAmount,
+          formatBtcAmount,
+        ),
+        "Staking Timelock": formatValue(
+          signPsbtOptions.stakingTimelock,
+          formatBlocks,
+        ),
+      }),
+
+      // Step 2: Consent to slashing during unbonding
+      getStep2Details: () => {
+        const details: Record<string, string> = {
+          "Unbonding Timelock": formatValue(
+            signPsbtOptions.unbondingTimelock,
+            formatBlocks,
+          ),
+          "Covenant Quorum": formatValue(
+            signPsbtOptions.covenantQuorum,
+            formatNumber,
+          ),
+        };
+
+        // Add individual covenant public keys as array
+        if (Array.isArray(signPsbtOptions.covenantPks)) {
+          details["Covenant PKs Count"] = formatValue(
+            signPsbtOptions.covenantPks,
+            (count) => `${formatNumber(count)} keys`,
+          );
+
+          // Add each covenant public key with its index
+          signPsbtOptions.covenantPks.forEach((pk, index) => {
+            details[`Covenant PK ${index + 1}`] = formatValue(pk, formatPK);
+          });
+        }
+
+        return details;
+      },
+
+      // Step 3: Address binding
+      getStep3Details: () => ({
+        "BABY Address": formatValue(bech32Address),
+      }),
+
+      // Step 4: Transaction registration
+      getStep4Details: () => ({}),
+    };
+  }, [getSignPsbtOptions, bech32Address]);
+
+  const step1Details = useMemo(
+    () => getStepDetails.getStep1Details(),
+    [getStepDetails],
+  );
+  const step2Details = useMemo(
+    () => getStepDetails.getStep2Details(),
+    [getStepDetails],
+  );
+  const step3Details = useMemo(
+    () => getStepDetails.getStep3Details(),
+    [getStepDetails],
+  );
+  const step4Details = useMemo(
+    () => getStepDetails.getStep4Details(),
+    [getStepDetails],
+  );
+
+  return (
+    <ResponsiveDialog open={open} onClose={onClose} hasBackdrop>
+      <DialogHeader
+        title={title}
+        onClose={onClose}
+        className="text-accent-primary"
+      />
+
+      <DialogBody className="flex flex-col pb-8 pt-4 text-accent-primary gap-4">
+        <Text variant="body1" className="text-accent-secondary">
+          Please sign the following messages
+        </Text>
+
+        <div className="py-4 flex flex-col items-start gap-6">
+          <Step step={1} currentStep={step} details={step1Details}>
+            Consent to slashing
+          </Step>
+          <Step step={2} currentStep={step} details={step2Details}>
+            Consent to slashing during unbonding
+          </Step>
+          <Step step={3} currentStep={step} details={step3Details}>
+            {coinSymbol}-{bbnCoinSymbol} address binding for receiving staking
+            rewards
+          </Step>
+          <Step step={4} currentStep={step} details={step4Details}>
+            Staking transaction registration
+          </Step>
+        </div>
+      </DialogBody>
+
+      <DialogFooter className="flex gap-4">
+        {onClose && (
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={onClose}
+            className="flex-1 text-xs sm:text-base"
+          >
+            Cancel
+          </Button>
+        )}
+
+        {onSubmit && (
+          <Button
+            disabled={processing}
+            variant="contained"
+            className="flex-1 text-xs sm:text-base"
+            onClick={onSubmit}
+          >
+            {processing ? (
+              <Loader size={16} className="text-accent-contrast" />
+            ) : (
+              "Sign"
+            )}
+          </Button>
+        )}
+      </DialogFooter>
+    </ResponsiveDialog>
+  );
+};

--- a/src/app/components/Modals/SignModal/Step.tsx
+++ b/src/app/components/Modals/SignModal/Step.tsx
@@ -1,5 +1,6 @@
 import { Loader, Text } from "@babylonlabs-io/core-ui";
-import type { PropsWithChildren, ReactNode } from "react";
+import { PropsWithChildren, ReactNode, useState } from "react";
+import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
 import { IoCheckmarkSharp } from "react-icons/io5";
 import { twMerge } from "tailwind-merge";
 
@@ -7,6 +8,7 @@ interface StepProps {
   step: number;
   currentStep: number;
   children: ReactNode;
+  details?: Record<string, string>;
 }
 
 const renderIcon = (step: number, currentStep: number) => {
@@ -39,17 +41,63 @@ export const Step = ({
   step,
   currentStep,
   children,
-}: PropsWithChildren<StepProps>) => (
-  <div
-    className={twMerge(
-      "p-4 flex flex-row items-center justify-start gap-3 rounded border border-secondary-strokeLight bg-surface self-stretch",
-      step !== currentStep && "opacity-25",
-    )}
-  >
-    {renderIcon(step, currentStep)}
+  details,
+}: PropsWithChildren<StepProps>) => {
+  const [showDetails, setShowDetails] = useState(false);
 
-    <Text variant="body1" className="text-accent-primary">
-      Step {step}: {children}
-    </Text>
-  </div>
-);
+  return (
+    <div className="flex flex-col w-full border border-secondary-strokeLight rounded bg-surface">
+      <div
+        className={twMerge(
+          "p-4 flex flex-row items-center justify-between gap-3 self-stretch",
+          step !== currentStep && "opacity-25",
+        )}
+      >
+        <div className="flex flex-row items-center gap-3">
+          {renderIcon(step, currentStep)}
+          <Text variant="body1" className="text-accent-primary">
+            Step {step}: {children}
+          </Text>
+        </div>
+
+        {details && Object.keys(details).length > 0 && (
+          <button
+            className={twMerge(
+              "border border-secondary-strokeLight flex justify-center items-center rounded bg-surface px-4 py-2 gap-1 cursor-default",
+              step === currentStep &&
+                "hover:text-secondary-main cursor-pointer",
+            )}
+            onClick={() => step === currentStep && setShowDetails(!showDetails)}
+          >
+            <div className="hidden md:flex">
+              <Text variant="body2">Details</Text>
+            </div>
+            {showDetails ? (
+              <AiOutlineMinus size={16} />
+            ) : (
+              <AiOutlinePlus size={16} />
+            )}
+          </button>
+        )}
+      </div>
+
+      {showDetails && details && (
+        <div className="border border-secondary-strokeLight rounded p-6 max-h-48 overflow-y-auto mx-4 mb-4 bg-primary-contrast flex flex-col gap-4">
+          {Object.entries(details).map(([key, value]) => (
+            <div
+              key={key}
+              className="flex justify-between gap-2 mb-2 last:mb-0"
+            >
+              <Text variant="body2" className="text-accent-secondary">
+                {key}
+              </Text>
+              <Text variant="body2" className="text-accent-primary break-all">
+                {value}
+              </Text>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/context/wallet/BTCWalletProvider.tsx
+++ b/src/app/context/wallet/BTCWalletProvider.tsx
@@ -3,6 +3,7 @@ import {
   IBTCProvider,
   InscriptionIdentifier,
   Network,
+  SignPsbtOptions,
   useChainConnector,
   useWalletConnect,
 } from "@babylonlabs-io/wallet-connector";
@@ -47,8 +48,11 @@ interface BTCWalletContextProps {
   open: () => void;
   getAddress: () => Promise<string>;
   getPublicKeyHex: () => Promise<string>;
-  signPsbt: (psbtHex: string) => Promise<string>;
-  signPsbts: (psbtsHexes: string[]) => Promise<string[]>;
+  signPsbt: (psbtHex: string, options?: SignPsbtOptions) => Promise<string>;
+  signPsbts: (
+    psbtsHexes: string[],
+    options?: SignPsbtOptions[],
+  ) => Promise<string[]>;
   getNetwork: () => Promise<Network>;
   signMessage: (
     message: string,
@@ -267,10 +271,10 @@ export const BTCWalletProvider = ({ children }: PropsWithChildren) => {
     () => ({
       getAddress: async () => btcWalletProvider?.getAddress() ?? "",
       getPublicKeyHex: async () => btcWalletProvider?.getPublicKeyHex() ?? "",
-      signPsbt: async (psbtHex: string) =>
-        btcWalletProvider?.signPsbt(psbtHex) ?? "",
-      signPsbts: async (psbtsHexes: string[]) =>
-        btcWalletProvider?.signPsbts(psbtsHexes) ?? [],
+      signPsbt: async (psbtHex: string, options?: SignPsbtOptions) =>
+        btcWalletProvider?.signPsbt(psbtHex, options) ?? "",
+      signPsbts: async (psbtsHexes: string[], options?: SignPsbtOptions[]) =>
+        btcWalletProvider?.signPsbts(psbtsHexes, options) ?? [],
       getNetwork: async () =>
         btcWalletProvider?.getNetwork() ?? ({} as Network),
       signMessage: async (message: string, type: "ecdsa" | "bip322-simple") =>

--- a/src/app/hooks/services/useDelegationService.ts
+++ b/src/app/hooks/services/useDelegationService.ts
@@ -40,6 +40,7 @@ interface TxProps {
     unbondingSlashingTxHex: string;
     spendingHeight: number;
   };
+  unbondingTimelock?: number;
 }
 
 type DelegationCommand = (props: TxProps) => Promise<void>;
@@ -142,6 +143,7 @@ export function useDelegationService() {
         stakingTxHex,
         unbondingTxHex,
         covenantUnbondingSignatures,
+        unbondingTimelock,
       }: TxProps) => {
         if (!covenantUnbondingSignatures) {
           const clientError = new ClientError(
@@ -154,6 +156,12 @@ export function useDelegationService() {
           throw clientError;
         }
 
+        // TODO important logic to check
+        // Get the unbonding timelock from props or network params
+        const finalUnbondingTimelock =
+          unbondingTimelock ||
+          networkInfo?.params.bbnStakingParams.latestParam.unbondingTime;
+
         await submitUnbondingTx(
           stakingInput,
           paramsVersion,
@@ -163,6 +171,7 @@ export function useDelegationService() {
             btcPkHex: sig.covenantBtcPkHex,
             sigHex: sig.signatureHex,
           })),
+          finalUnbondingTimelock!,
         );
 
         updateDelegationStatus(
@@ -272,6 +281,7 @@ export function useDelegationService() {
       submitEarlyUnbondedWithdrawalTx,
       submitTimelockUnbondedWithdrawalTx,
       submitSlashingWithdrawalTx,
+      networkInfo?.params.bbnStakingParams.latestParam.unbondingTime,
     ],
   );
 
@@ -316,6 +326,7 @@ export function useDelegationService() {
         covenantUnbondingSignatures,
         state,
         slashing,
+        unbondingTimelock,
       } = delegation;
 
       const finalityProviderPk = finalityProviderBtcPksHex[0];
@@ -339,6 +350,7 @@ export function useDelegationService() {
           state,
           stakingInput,
           slashing,
+          unbondingTimelock,
         });
 
         closeConfirmationModal();

--- a/src/app/hooks/services/useStakingManagerService.ts
+++ b/src/app/hooks/services/useStakingManagerService.ts
@@ -7,7 +7,9 @@ import { useCallback, useRef } from "react";
 
 import { useBTCWallet } from "@/app/context/wallet/BTCWalletProvider";
 import { useCosmosWallet } from "@/app/context/wallet/CosmosWalletProvider";
+import { useNetworkInfo } from "@/app/hooks/client/api/useNetworkInfo";
 import { useBbnTransaction } from "@/app/hooks/client/rpc/mutation/useBbnTransaction";
+import { useComposedSignOptionsData } from "@/app/hooks/useComposedSignOptions";
 import { useAppState } from "@/app/state";
 import { useLogger } from "@/hooks/useLogger";
 
@@ -18,6 +20,7 @@ const stakingManagerEvents = {
 export const useStakingManagerService = () => {
   const { networkInfo } = useAppState();
   const { signBbnTx } = useBbnTransaction();
+  const { data: networkInfoAPI } = useNetworkInfo();
   const logger = useLogger();
 
   const { connected: cosmosConnected } = useCosmosWallet();
@@ -26,79 +29,95 @@ export const useStakingManagerService = () => {
     connected: btcConnected,
     signPsbt,
     signMessage,
+    publicKeyNoCoord,
   } = useBTCWallet();
+  const { bech32Address } = useCosmosWallet();
 
   const versionedParams = networkInfo?.params.bbnStakingParams?.versions;
 
   const { current: eventEmitter } = useRef<EventEmitter>(new EventEmitter());
 
-  const createBtcStakingManager = useCallback(() => {
-    if (
-      !btcNetwork ||
-      !cosmosConnected ||
-      !btcConnected ||
-      !signPsbt ||
-      !signMessage ||
-      !signBbnTx ||
-      !versionedParams ||
-      versionedParams.length === 0
-    ) {
-      logger.info("createBtcStakingManager", {
-        cosmosConnected,
-        btcConnected,
-        btcNetwork: Boolean(btcNetwork),
-        signPsbt: Boolean(signPsbt),
-        signMessage: Boolean(signMessage),
-        signBbnTx: Boolean(signBbnTx),
-        versionedParams: Boolean(versionedParams),
-      });
-      return null;
-    }
+  const { getSignPsbtOptions } = useComposedSignOptionsData();
 
-    const btcProvider = {
-      signPsbt: async (signingStep: SigningStep, psbt: string) => {
-        eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-        return signPsbt(psbt);
-      },
-      signMessage: async (
-        signingStep: SigningStep,
-        message: string,
-        type: "ecdsa" | "bip322-simple",
-      ) => {
-        eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-        return signMessage(message, type);
-      },
-    };
+  const createBtcStakingManager = useCallback(
+    (
+      finalityProviderPK?: string,
+      stakingTimelock?: number,
+      unbondingTimelock?: number,
+    ) => {
+      if (
+        !btcNetwork ||
+        !cosmosConnected ||
+        !btcConnected ||
+        !signPsbt ||
+        !signMessage ||
+        !signBbnTx ||
+        !versionedParams ||
+        versionedParams.length === 0
+      ) {
+        logger.info("createBtcStakingManager", {
+          cosmosConnected,
+          btcConnected,
+          btcNetwork: Boolean(btcNetwork),
+          signPsbt: Boolean(signPsbt),
+          signMessage: Boolean(signMessage),
+          signBbnTx: Boolean(signBbnTx),
+          versionedParams: Boolean(versionedParams),
+        });
+        return null;
+      }
 
-    const bbnProvider = {
-      signTransaction: async <T extends object>(
-        signingStep: SigningStep,
-        msg: {
-          typeUrl: string;
-          value: T;
+      const btcProvider = {
+        signPsbt: async (signingStep: SigningStep, psbt: string) => {
+          eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
+
+          const options = getSignPsbtOptions(signingStep);
+
+          return signPsbt(psbt, options);
         },
-      ) => {
-        eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-        return signBbnTx(msg);
-      },
-    };
+        signMessage: async (
+          signingStep: SigningStep,
+          message: string,
+          type: "ecdsa" | "bip322-simple",
+        ) => {
+          eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
+          return signMessage(message, type);
+        },
+      };
 
-    return new BabylonBtcStakingManager(
+      const bbnProvider = {
+        signTransaction: async <T extends object>(
+          signingStep: SigningStep,
+          msg: {
+            typeUrl: string;
+            value: T;
+          },
+        ) => {
+          eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
+          return signBbnTx(msg);
+        },
+      };
+
+      return new BabylonBtcStakingManager(
+        btcNetwork,
+        versionedParams,
+        btcProvider,
+        bbnProvider,
+      );
+    },
+    [
       btcNetwork,
+      cosmosConnected,
+      btcConnected,
+      signPsbt,
+      signMessage,
+      signBbnTx,
       versionedParams,
-      btcProvider,
-      bbnProvider,
-    );
-  }, [
-    btcNetwork,
-    cosmosConnected,
-    btcConnected,
-    signPsbt,
-    signMessage,
-    signBbnTx,
-    versionedParams,
-    eventEmitter,
-  ]);
+      eventEmitter,
+      logger,
+      getSignPsbtOptions,
+    ],
+  );
 
   const on = useCallback(
     (callback: (step: SigningStep) => void) => {

--- a/src/app/hooks/services/useStakingManagerService.ts
+++ b/src/app/hooks/services/useStakingManagerService.ts
@@ -7,9 +7,7 @@ import { useCallback, useRef } from "react";
 
 import { useBTCWallet } from "@/app/context/wallet/BTCWalletProvider";
 import { useCosmosWallet } from "@/app/context/wallet/CosmosWalletProvider";
-import { useNetworkInfo } from "@/app/hooks/client/api/useNetworkInfo";
 import { useBbnTransaction } from "@/app/hooks/client/rpc/mutation/useBbnTransaction";
-import { useComposedSignOptionsData } from "@/app/hooks/useComposedSignOptions";
 import { useAppState } from "@/app/state";
 import { useLogger } from "@/hooks/useLogger";
 
@@ -20,7 +18,6 @@ const stakingManagerEvents = {
 export const useStakingManagerService = () => {
   const { networkInfo } = useAppState();
   const { signBbnTx } = useBbnTransaction();
-  const { data: networkInfoAPI } = useNetworkInfo();
   const logger = useLogger();
 
   const { connected: cosmosConnected } = useCosmosWallet();
@@ -29,95 +26,80 @@ export const useStakingManagerService = () => {
     connected: btcConnected,
     signPsbt,
     signMessage,
-    publicKeyNoCoord,
   } = useBTCWallet();
-  const { bech32Address } = useCosmosWallet();
 
   const versionedParams = networkInfo?.params.bbnStakingParams?.versions;
 
   const { current: eventEmitter } = useRef<EventEmitter>(new EventEmitter());
 
-  const { getSignPsbtOptions } = useComposedSignOptionsData();
+  const createBtcStakingManager = useCallback(() => {
+    if (
+      !btcNetwork ||
+      !cosmosConnected ||
+      !btcConnected ||
+      !signPsbt ||
+      !signMessage ||
+      !signBbnTx ||
+      !versionedParams ||
+      versionedParams.length === 0
+    ) {
+      logger.info("createBtcStakingManager", {
+        cosmosConnected,
+        btcConnected,
+        btcNetwork: Boolean(btcNetwork),
+        signPsbt: Boolean(signPsbt),
+        signMessage: Boolean(signMessage),
+        signBbnTx: Boolean(signBbnTx),
+        versionedParams: Boolean(versionedParams),
+      });
+      return null;
+    }
 
-  const createBtcStakingManager = useCallback(
-    (
-      finalityProviderPK?: string,
-      stakingTimelock?: number,
-      unbondingTimelock?: number,
-    ) => {
-      if (
-        !btcNetwork ||
-        !cosmosConnected ||
-        !btcConnected ||
-        !signPsbt ||
-        !signMessage ||
-        !signBbnTx ||
-        !versionedParams ||
-        versionedParams.length === 0
-      ) {
-        logger.info("createBtcStakingManager", {
-          cosmosConnected,
-          btcConnected,
-          btcNetwork: Boolean(btcNetwork),
-          signPsbt: Boolean(signPsbt),
-          signMessage: Boolean(signMessage),
-          signBbnTx: Boolean(signBbnTx),
-          versionedParams: Boolean(versionedParams),
-        });
-        return null;
-      }
+    const btcProvider = {
+      signPsbt: async (signingStep: SigningStep, psbt: string) => {
+        eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
+        return signPsbt(psbt);
+      },
+      signMessage: async (
+        signingStep: SigningStep,
+        message: string,
+        type: "ecdsa" | "bip322-simple",
+      ) => {
+        eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
+        return signMessage(message, type);
+      },
+    };
 
-      const btcProvider = {
-        signPsbt: async (signingStep: SigningStep, psbt: string) => {
-          eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-
-          const options = getSignPsbtOptions(signingStep);
-
-          return signPsbt(psbt, options);
+    const bbnProvider = {
+      signTransaction: async <T extends object>(
+        signingStep: SigningStep,
+        msg: {
+          typeUrl: string;
+          value: T;
         },
-        signMessage: async (
-          signingStep: SigningStep,
-          message: string,
-          type: "ecdsa" | "bip322-simple",
-        ) => {
-          eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-          return signMessage(message, type);
-        },
-      };
+      ) => {
+        eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
+        return signBbnTx(msg);
+      },
+    };
 
-      const bbnProvider = {
-        signTransaction: async <T extends object>(
-          signingStep: SigningStep,
-          msg: {
-            typeUrl: string;
-            value: T;
-          },
-        ) => {
-          eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-          return signBbnTx(msg);
-        },
-      };
-
-      return new BabylonBtcStakingManager(
-        btcNetwork,
-        versionedParams,
-        btcProvider,
-        bbnProvider,
-      );
-    },
-    [
+    return new BabylonBtcStakingManager(
       btcNetwork,
-      cosmosConnected,
-      btcConnected,
-      signPsbt,
-      signMessage,
-      signBbnTx,
       versionedParams,
-      eventEmitter,
-      logger,
-      getSignPsbtOptions,
-    ],
-  );
+      btcProvider,
+      bbnProvider,
+    );
+  }, [
+    btcNetwork,
+    cosmosConnected,
+    btcConnected,
+    signPsbt,
+    signMessage,
+    signBbnTx,
+    versionedParams,
+    eventEmitter,
+    logger,
+  ]);
 
   const on = useCallback(
     (callback: (step: SigningStep) => void) => {

--- a/src/app/hooks/services/useStakingManagerService.ts
+++ b/src/app/hooks/services/useStakingManagerService.ts
@@ -2,6 +2,7 @@ import {
   BabylonBtcStakingManager,
   SigningStep,
 } from "@babylonlabs-io/btc-staking-ts";
+import { SignPsbtOptions } from "@babylonlabs-io/wallet-connector";
 import { EventEmitter } from "events";
 import { useCallback, useRef } from "react";
 
@@ -56,9 +57,22 @@ export const useStakingManagerService = () => {
     }
 
     const btcProvider = {
-      signPsbt: async (signingStep: SigningStep, psbt: string) => {
+      signPsbt: async (
+        signingStep: SigningStep,
+        psbt: string,
+        options: SignPsbtOptions,
+      ) => {
         eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-        return signPsbt(psbt);
+        console.log(
+          "btcProvider",
+          "signingStep",
+          signingStep,
+          "psbt",
+          psbt,
+          "options",
+          options,
+        );
+        return signPsbt(psbt, options);
       },
       signMessage: async (
         signingStep: SigningStep,

--- a/src/app/hooks/services/useTransactionService.ts
+++ b/src/app/hooks/services/useTransactionService.ts
@@ -67,7 +67,12 @@ export const useTransactionService = () => {
         stakingInput: JSON.stringify(stakingInput),
         feeRate,
       });
-      const btcStakingManager = createBtcStakingManager();
+      const { finalityProviderPkNoCoordHex, stakingTimelock } = stakingInput;
+
+      const btcStakingManager = createBtcStakingManager(
+        finalityProviderPkNoCoordHex,
+        stakingTimelock,
+      );
 
       validateCommonInputs(
         btcStakingManager,
@@ -230,7 +235,12 @@ export const useTransactionService = () => {
         paramVersion,
         expectedTxHashHex,
       });
-      const btcStakingManager = createBtcStakingManager();
+      const { finalityProviderPkNoCoordHex, stakingTimelock } = stakingInput;
+
+      const btcStakingManager = createBtcStakingManager(
+        finalityProviderPkNoCoordHex,
+        stakingTimelock,
+      );
       validateCommonInputs(
         btcStakingManager,
         stakingInput,
@@ -298,6 +308,7 @@ export const useTransactionService = () => {
    * @param stakingTxHex - The staking transaction hex
    * @param unbondingTxHex - The unbonding transaction hex
    * @param covenantUnbondingSignatures - The covenant unbonding signatures
+   * @param unbondingTimelock - The unbonding timelock
    */
   const submitUnbondingTx = useCallback(
     async (
@@ -309,8 +320,16 @@ export const useTransactionService = () => {
         btcPkHex: string;
         sigHex: string;
       }[],
+      unbondingTimelock: number,
     ) => {
-      const btcStakingManager = createBtcStakingManager();
+      const { finalityProviderPkNoCoordHex, stakingTimelock } = stakingInput;
+
+      const btcStakingManager = createBtcStakingManager(
+        finalityProviderPkNoCoordHex,
+        stakingTimelock,
+        unbondingTimelock,
+      );
+
       validateCommonInputs(
         btcStakingManager,
         stakingInput,

--- a/src/app/hooks/useComposedSignOptions.ts
+++ b/src/app/hooks/useComposedSignOptions.ts
@@ -1,0 +1,68 @@
+import { SigningStep } from "@babylonlabs-io/btc-staking-ts";
+import { SignPsbtOptions } from "@babylonlabs-io/wallet-connector";
+import { useCallback } from "react";
+
+import { useBTCWallet } from "@/app/context/wallet/BTCWalletProvider";
+import { useAppState } from "@/app/state";
+import { useStakingState } from "@/app/state/StakingState";
+
+export function useComposedSignOptionsData() {
+  const { publicKeyNoCoord } = useBTCWallet();
+  const { networkInfo } = useAppState();
+  const { formData } = useStakingState();
+
+  const getSignPsbtOptions = useCallback(
+    (signingStep?: SigningStep): SignPsbtOptions => {
+      const latestNetworkParams =
+        networkInfo?.params?.bbnStakingParams?.latestParam;
+
+      const params: Record<string, string | number | string[] | number[]> = {
+        stakerPk: publicKeyNoCoord,
+        magicBytes: "62627434", // TODO remove once not needed from Unisat side
+      };
+
+      // Logic is explicit but easier to read
+      if (signingStep !== undefined) {
+        params.type = signingStep;
+      }
+
+      if (formData?.finalityProvider) {
+        params.finalityProviders = [formData.finalityProvider];
+      }
+
+      if (formData?.term !== undefined) {
+        params.stakingDuration = formData.term;
+      }
+
+      if (latestNetworkParams) {
+        if (latestNetworkParams.covenantNoCoordPks) {
+          params.covenantPks = latestNetworkParams.covenantNoCoordPks;
+        }
+
+        if (latestNetworkParams.covenantQuorum !== undefined) {
+          params.covenantThreshold = latestNetworkParams.covenantQuorum;
+        }
+
+        if (latestNetworkParams.unbondingTime !== undefined) {
+          params.minUnbondingTime = latestNetworkParams.unbondingTime;
+        }
+      }
+
+      const options: SignPsbtOptions = {
+        contracts: [
+          {
+            id: "babylon:staking",
+            params,
+          },
+        ],
+      };
+
+      return options;
+    },
+    [networkInfo, formData, publicKeyNoCoord],
+  );
+
+  return {
+    getSignPsbtOptions,
+  };
+}

--- a/tests/app/hooks/services/errorHandling.test.tsx
+++ b/tests/app/hooks/services/errorHandling.test.tsx
@@ -19,12 +19,11 @@ jest.mock("@uidotdev/usehooks", () => ({
 
 // Import after mocks
 import { act, renderHook } from "@testing-library/react";
-import { PropsWithChildren } from "react";
 
 import { getDelegationV2 } from "@/app/api/getDelegationsV2";
 import { HttpStatusCode } from "@/app/api/httpStatusCodes";
 import { ClientErrorCategory } from "@/app/constants/errorMessages";
-import { useError } from "@/app/context/Error/ErrorProvider";
+import { ErrorProvider, useError } from "@/app/context/Error/ErrorProvider";
 import { ClientError } from "@/app/context/Error/errors/clientError";
 import { ServerError } from "@/app/context/Error/errors/serverError";
 import { useBTCWallet } from "@/app/context/wallet/BTCWalletProvider";
@@ -65,7 +64,12 @@ jest.mock("@babylonlabs-io/btc-staking-ts", () => ({
 }));
 
 // Create a test wrapper
-const TestWrapper = ({ children }: PropsWithChildren) => <>{children}</>;
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ErrorProvider>
+    {/* Your existing wrapper providers */}
+    {children}
+  </ErrorProvider>
+);
 
 // Mock data for tests
 const mockFormData = {

--- a/tests/app/hooks/services/errorHandling.test.tsx
+++ b/tests/app/hooks/services/errorHandling.test.tsx
@@ -19,11 +19,12 @@ jest.mock("@uidotdev/usehooks", () => ({
 
 // Import after mocks
 import { act, renderHook } from "@testing-library/react";
+import { PropsWithChildren } from "react";
 
 import { getDelegationV2 } from "@/app/api/getDelegationsV2";
 import { HttpStatusCode } from "@/app/api/httpStatusCodes";
 import { ClientErrorCategory } from "@/app/constants/errorMessages";
-import { ErrorProvider, useError } from "@/app/context/Error/ErrorProvider";
+import { useError } from "@/app/context/Error/ErrorProvider";
 import { ClientError } from "@/app/context/Error/errors/clientError";
 import { ServerError } from "@/app/context/Error/errors/serverError";
 import { useBTCWallet } from "@/app/context/wallet/BTCWalletProvider";
@@ -64,12 +65,7 @@ jest.mock("@babylonlabs-io/btc-staking-ts", () => ({
 }));
 
 // Create a test wrapper
-const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <ErrorProvider>
-    {/* Your existing wrapper providers */}
-    {children}
-  </ErrorProvider>
-);
+const TestWrapper = ({ children }: PropsWithChildren) => <>{children}</>;
 
 // Mock data for tests
 const mockFormData = {


### PR DESCRIPTION
This PR adds an ability for `simple-staking` to see the signing data

- @0xDazzer @jonybur can you check the `src/app/context/transaction/TransactionProvider.tsx`? Is there a better way to have the data:

```
  // Form data
  finalityProviderPK: string | undefined;
  stakingAmount: number;
  stakingTimelock: number | undefined;

  // Network
  covenantNoCoordPks: string[] | undefined;
  covenantQuorum: number | undefined;
  unbondingTimelock: number | undefined;

  // Wallet data
  publicKeyNoCoord: string | undefined;
  bbnAddress: string | undefined;

  // Current signing step
  currentStep: SigningStep | undefined;
```

---

@jrwbabylonlab what data (`key-value pairs`) should we show for:
- `step 1 - slashing`
- `step 2 - slashing unbonding`
- `staking`
- `unbonding`
- `withdrawal`

---

@0xDazzer suggestion

- `options` can be used in `btc-staking-ts` when calling `signPsbt`, it might have all the data we need
- `StakingState` - form
- `useStakingService`