### PR TITLE
feat: Sign PSBT options

### DIFF
--- a/src/app/context/wallet/BTCWalletProvider.tsx
+++ b/src/app/context/wallet/BTCWalletProvider.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { SignPsbtOptions } from "@babylonlabs-io/btc-staking-ts";
 import {
   IBTCProvider,
   InscriptionIdentifier,
@@ -47,8 +48,11 @@ interface BTCWalletContextProps {
   open: () => void;
   getAddress: () => Promise<string>;
   getPublicKeyHex: () => Promise<string>;
-  signPsbt: (psbtHex: string) => Promise<string>;
-  signPsbts: (psbtsHexes: string[]) => Promise<string[]>;
+  signPsbt: (psbtHex: string, options?: SignPsbtOptions) => Promise<string>;
+  signPsbts: (
+    psbtsHexes: string[],
+    options?: SignPsbtOptions[],
+  ) => Promise<string[]>;
   getNetwork: () => Promise<Network>;
   signMessage: (
     message: string,
@@ -267,10 +271,10 @@ export const BTCWalletProvider = ({ children }: PropsWithChildren) => {
     () => ({
       getAddress: async () => btcWalletProvider?.getAddress() ?? "",
       getPublicKeyHex: async () => btcWalletProvider?.getPublicKeyHex() ?? "",
-      signPsbt: async (psbtHex: string) =>
-        btcWalletProvider?.signPsbt(psbtHex) ?? "",
-      signPsbts: async (psbtsHexes: string[]) =>
-        btcWalletProvider?.signPsbts(psbtsHexes) ?? [],
+      signPsbt: async (psbtHex: string, options?: SignPsbtOptions) =>
+        btcWalletProvider?.signPsbt(psbtHex, options) ?? "",
+      signPsbts: async (psbtsHexes: string[], options?: SignPsbtOptions[]) =>
+        btcWalletProvider?.signPsbts(psbtsHexes, options) ?? [],
       getNetwork: async () =>
         btcWalletProvider?.getNetwork() ?? ({} as Network),
       signMessage: async (message: string, type: "ecdsa" | "bip322-simple") =>

--- a/src/app/hooks/services/useStakingManagerService.ts
+++ b/src/app/hooks/services/useStakingManagerService.ts
@@ -1,5 +1,6 @@
 import {
   BabylonBtcStakingManager,
+  SignPsbtOptions,
   SigningStep,
 } from "@babylonlabs-io/btc-staking-ts";
 import { EventEmitter } from "events";
@@ -56,9 +57,13 @@ export const useStakingManagerService = () => {
     }
 
     const btcProvider = {
-      signPsbt: async (signingStep: SigningStep, psbt: string) => {
+      signPsbt: async (
+        signingStep: SigningStep,
+        psbt: string,
+        options: SignPsbtOptions,
+      ) => {
         eventEmitter.emit(stakingManagerEvents.SIGNING, signingStep);
-        return signPsbt(psbt);
+        return signPsbt(psbt, options);
       },
       signMessage: async (
         signingStep: SigningStep,


### PR DESCRIPTION
Passes `options` when `signPsbt` is called
Relevant PR: https://github.com/babylonlabs-io/btc-staking-ts/pull/103