### PR TITLE
feat: add feature flags component tests

### DIFF
--- a/e2e/fixtures/form.selectors.ts
+++ b/e2e/fixtures/form.selectors.ts
@@ -1,0 +1,16 @@
+export const MULTISTAKING_FORM_SELECTORS = {
+  CHAIN_SELECTION_BUTTON: "text=Select Available BSN",
+  FP_SELECTION_BUTTON: "text=Select Babylon Genesis Finality Provider",
+};
+
+// TODO: Replace with data-testid selectors when components are updated
+export const STAKING_FORM_SELECTORS = {
+  STEP_2_HEADING: "text=Step 2",
+  SET_AMOUNT_TEXT: "text=Set Staking Amount",
+  PREVIEW_BUTTON: 'button:has-text("Preview")',
+};
+
+export const FORM_SELECTORS = {
+  MULTISTAKING: MULTISTAKING_FORM_SELECTORS,
+  STAKING: STAKING_FORM_SELECTORS,
+};

--- a/e2e/fixtures/form.ts
+++ b/e2e/fixtures/form.ts
@@ -1,0 +1,63 @@
+import { expect, Page } from "@playwright/test";
+
+import { FORM_SELECTORS } from "./form.selectors";
+
+export class FormActions {
+  constructor(private page: Page) {}
+
+  async verifyMultistakingFormNotVisible() {
+    const chainSelectionButton = this.page.locator(
+      FORM_SELECTORS.MULTISTAKING.CHAIN_SELECTION_BUTTON,
+    );
+    const fpSelectionButton = this.page.locator(
+      FORM_SELECTORS.MULTISTAKING.FP_SELECTION_BUTTON,
+    );
+
+    await expect(chainSelectionButton).not.toBeVisible();
+    await expect(fpSelectionButton).not.toBeVisible();
+  }
+
+  async verifyStakingFormVisible() {
+    const step2Heading = this.page.locator(
+      FORM_SELECTORS.STAKING.STEP_2_HEADING,
+    );
+    const setAmountText = this.page.locator(
+      FORM_SELECTORS.STAKING.SET_AMOUNT_TEXT,
+    );
+    const previewButton = this.page.locator(
+      FORM_SELECTORS.STAKING.PREVIEW_BUTTON,
+    );
+
+    await expect(step2Heading).toBeVisible();
+    await expect(setAmountText).toBeVisible();
+    await expect(previewButton).toBeVisible();
+  }
+
+  async verifyMultistakingFormVisible() {
+    const chainSelectionButton = this.page.locator(
+      FORM_SELECTORS.MULTISTAKING.CHAIN_SELECTION_BUTTON,
+    );
+    const fpSelectionButton = this.page.locator(
+      FORM_SELECTORS.MULTISTAKING.FP_SELECTION_BUTTON,
+    );
+
+    await expect(chainSelectionButton).toBeVisible();
+    await expect(fpSelectionButton).toBeVisible();
+  }
+
+  async verifyStakingFormNotVisible() {
+    const step2Heading = this.page.locator(
+      FORM_SELECTORS.STAKING.STEP_2_HEADING,
+    );
+    const setAmountText = this.page.locator(
+      FORM_SELECTORS.STAKING.SET_AMOUNT_TEXT,
+    );
+    const previewButton = this.page.locator(
+      FORM_SELECTORS.STAKING.PREVIEW_BUTTON,
+    );
+
+    await expect(step2Heading).not.toBeVisible();
+    await expect(setAmountText).not.toBeVisible();
+    await expect(previewButton).not.toBeVisible();
+  }
+}

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,3 +1,4 @@
+export * from "./form";
 export * from "./page_navigation";
 export * from "./wallet_balance";
 export * from "./wallet_connect";

--- a/e2e/specs/featureFlag.spec.ts
+++ b/e2e/specs/featureFlag.spec.ts
@@ -1,12 +1,14 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 
-import { PageNavigationActions } from "../fixtures";
+import { FormActions, PageNavigationActions } from "../fixtures";
 
 test.describe("Feature Flag - Multistaking", () => {
   let navigationActions: PageNavigationActions;
+  let formActions: FormActions;
 
   test.beforeEach(async ({ page }) => {
     navigationActions = new PageNavigationActions(page);
+    formActions = new FormActions(page);
   });
 
   test("should ensure correct component is rendered when the feature flag is set", async ({
@@ -17,19 +19,9 @@ test.describe("Feature Flag - Multistaking", () => {
     await navigationActions.navigateToHomePage(page);
 
     // Verify MultistakingForm elements are not visible
-    const chainSelectionButton = page.locator("text=Select Available BSN");
-    const fpSelectionButton = page.locator(
-      "text=Select Babylon Genesis Finality Provider",
-    );
-    await expect(chainSelectionButton).not.toBeVisible();
-    await expect(fpSelectionButton).not.toBeVisible();
+    await formActions.verifyMultistakingFormNotVisible();
 
     // Verify StakingForm elements are visible
-    const step2Heading = page.locator("text=Step 2");
-    const setAmountText = page.locator("text=Set Staking Amount");
-    const previewButton = page.locator("button").filter({ hasText: "Preview" });
-    await expect(step2Heading).toBeVisible();
-    await expect(setAmountText).toBeVisible();
-    await expect(previewButton).toBeVisible();
+    await formActions.verifyStakingFormVisible();
   });
 });

--- a/e2e/specs/featureFlag.spec.ts
+++ b/e2e/specs/featureFlag.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+import { PageNavigationActions } from "../fixtures";
+
+test.describe("Feature Flag - Multistaking", () => {
+  let navigationActions: PageNavigationActions;
+
+  test.beforeEach(async ({ page }) => {
+    navigationActions = new PageNavigationActions(page);
+  });
+
+  test("should ensure correct component is rendered when the feature flag is set", async ({
+    page,
+  }) => {
+    process.env.FF_MULTISTAKING = "false";
+
+    await navigationActions.navigateToHomePage(page);
+
+    // Verify MultistakingForm elements are not visible
+    const chainSelectionButton = page.locator("text=Select Available BSN");
+    const fpSelectionButton = page.locator(
+      "text=Select Babylon Genesis Finality Provider",
+    );
+    await expect(chainSelectionButton).not.toBeVisible();
+    await expect(fpSelectionButton).not.toBeVisible();
+
+    // Verify StakingForm elements are visible
+    const step2Heading = page.locator("text=Step 2");
+    const setAmountText = page.locator("text=Set Staking Amount");
+    const previewButton = page.locator("button").filter({ hasText: "Preview" });
+    await expect(step2Heading).toBeVisible();
+    await expect(setAmountText).toBeVisible();
+    await expect(previewButton).toBeVisible();
+  });
+});


### PR DESCRIPTION
This ensures that when configures FF_MULTISTAKING=false, users will see the correct staking interface and not accidentally see the multistaking interface