### PR TITLE
chore: bump btc-staking-ts and wallet-connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.9",
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "1.0.1",
-        "@babylonlabs-io/btc-staking-ts": "1.0.11",
+        "@babylonlabs-io/btc-staking-ts": "1.0.12",
         "@babylonlabs-io/core-ui": "1.1.1",
-        "@babylonlabs-io/wallet-connector": "1.4.5",
+        "@babylonlabs-io/wallet-connector": "1.4.6",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
         "@cosmjs/proto-signing": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
@@ -1966,9 +1966,9 @@
       }
     },
     "node_modules/@babylonlabs-io/btc-staking-ts": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-1.0.11.tgz",
-      "integrity": "sha512-847NQysC9kXz1K/MpqwI2PC542A7B40BNNLlTxJK+KbotOCDUuu2h/jObZLF8Psc0zDKkrlWf0VzQmNuqEaBWA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-1.0.12.tgz",
+      "integrity": "sha512-x5uhDxbMdPgKUuI+bcIha2aSPUjDcrMqXNvO3ZxUP0NB0/VXoW9Fj4fhdOQ5aa373qi5ZEdTVTkJUfE8HI0X+Q==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "1.0.1",
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/@babylonlabs-io/wallet-connector": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.4.5.tgz",
-      "integrity": "sha512-wH/hvyqI6EM6n7Q2ueLDvSJChN8wVB0b9soIonWXZPxu0TX91jKAXBTVXkQ3eUE6af9gnZY/REkHMkkhgUiOhQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.4.6.tgz",
+      "integrity": "sha512-NwIZ0ScX0XlzfdDrmGn50JfvSS+x8MYtYIMfC0ZpmkxvuRgtqQsMwD/PPcFl18URCAaENoWHom7G8FTs/tE/tw==",
       "dependencies": {
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/provider-extension": "^0.12.204",
@@ -2027,7 +2027,7 @@
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
-        "@babylonlabs-io/btc-staking-ts": "1.0.11",
+        "@babylonlabs-io/btc-staking-ts": "1.0.12",
         "@babylonlabs-io/core-ui": "1.1.1",
         "bitcoinjs-lib": "6.1.5",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@babylonlabs-io/babylon-proto-ts": "1.0.1",
-    "@babylonlabs-io/btc-staking-ts": "1.0.11",
+    "@babylonlabs-io/btc-staking-ts": "1.0.12",
     "@babylonlabs-io/core-ui": "1.1.1",
-    "@babylonlabs-io/wallet-connector": "1.4.5",
+    "@babylonlabs-io/wallet-connector": "1.4.6",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",


### PR DESCRIPTION
Bumps `btc-staking-ts` and `wallet-connector` to start receiving `signPsbt` contracts