### PR TITLE
feat: Unisat contract UI

### DIFF
--- a/src/app/components/Delegations/Delegations.tsx
+++ b/src/app/components/Delegations/Delegations.tsx
@@ -7,6 +7,7 @@ import { useLocalStorage } from "usehooks-ts";
 import { LoadingTableList } from "@/app/components/Loading/Loading";
 import { RegistrationEndModal } from "@/app/components/Modals/RegistrationModal/RegistrationEndModal";
 import { RegistrationStartModal } from "@/app/components/Modals/RegistrationModal/RegistrationStartModal";
+import { SignDetailsModal } from "@/app/components/Modals/SignDetailsModal";
 import { SignModal } from "@/app/components/Modals/SignModal/SignModal";
 import { WithdrawModal } from "@/app/components/Modals/WithdrawModal";
 import { ONE_MINUTE } from "@/app/constants";
@@ -18,6 +19,7 @@ import { useNetworkInfo } from "@/app/hooks/client/api/useNetworkInfo";
 import { useRegistrationService } from "@/app/hooks/services/useRegistrationService";
 import { useV1TransactionService } from "@/app/hooks/services/useV1TransactionService";
 import { useDelegationState } from "@/app/state/DelegationState";
+import { useDelegationV2State } from "@/app/state/DelegationV2State";
 import {
   Delegation as DelegationInterface,
   DelegationState,
@@ -77,6 +79,7 @@ export const Delegations = ({}) => {
 
   const { submitWithdrawalTx, submitUnbondingTx } = useV1TransactionService();
   const { data: networkFees } = useNetworkFees();
+  const { currentStepOptions, setCurrentStepOptions } = useDelegationV2State();
 
   const selectedDelegation = delegationsAPI?.delegations.find(
     (delegation) => delegation.stakingTxHashHex === txID,
@@ -198,10 +201,7 @@ export const Delegations = ({}) => {
         error,
       });
     } finally {
-      setModalOpen(false);
-      setTxID("");
-      setModalMode(undefined);
-      setAwaitingWalletResponse(false);
+      handleModalClose();
     }
   };
 
@@ -254,10 +254,7 @@ export const Delegations = ({}) => {
         },
       });
     } finally {
-      setModalOpen(false);
-      setTxID("");
-      setModalMode(undefined);
-      setAwaitingWalletResponse(false);
+      handleModalClose();
     }
   };
 
@@ -265,6 +262,16 @@ export const Delegations = ({}) => {
     setModalOpen(true);
     setTxID(txID);
     setModalMode(mode);
+  };
+
+  const handleModalClose = () => {
+    setModalOpen(false);
+    setTxID("");
+    setModalMode(undefined);
+    setAwaitingWalletResponse(false);
+    setCurrentStepOptions(undefined);
+    setSelectedDelegation(undefined);
+    setStep(undefined);
   };
 
   useEffect(() => {
@@ -428,7 +435,7 @@ export const Delegations = ({}) => {
       {modalMode === MODE_WITHDRAW && txID && selectedDelegation && (
         <WithdrawModal
           open={modalOpen}
-          onClose={() => setModalOpen(false)}
+          onClose={handleModalClose}
           onSubmit={() => {
             handleWithdraw(txID);
           }}
@@ -438,7 +445,7 @@ export const Delegations = ({}) => {
       {modalMode === MODE_UNBOND && (
         <UnbondModal
           open={modalOpen}
-          onClose={() => setModalOpen(false)}
+          onClose={handleModalClose}
           onSubmit={() => {
             handleUnbond(txID);
           }}
@@ -474,6 +481,15 @@ export const Delegations = ({}) => {
         open={step === "registration-verified"}
         onClose={handleCloseRegistration}
       />
+
+      {currentStepOptions && (
+        <SignDetailsModal
+          open={Boolean(currentStepOptions)}
+          onClose={handleModalClose}
+          details={currentStepOptions}
+          title="Transaction Details"
+        />
+      )}
     </>
   );
 };

--- a/src/app/components/Modals/SignDetailsModal.tsx
+++ b/src/app/components/Modals/SignDetailsModal.tsx
@@ -1,0 +1,49 @@
+import {
+  Button,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+} from "@babylonlabs-io/core-ui";
+import { SignPsbtOptions } from "@babylonlabs-io/wallet-connector";
+
+import { ResponsiveDialog } from "@/app/components/Modals/ResponsiveDialog";
+import { SignDetails } from "@/app/components/SignDetails/SignDetails";
+
+interface SignDetailsModalProps {
+  open: boolean;
+  onClose: () => void;
+  details: SignPsbtOptions | Record<string, string>;
+  title?: string;
+}
+
+export const SignDetailsModal: React.FC<SignDetailsModalProps> = ({
+  open,
+  onClose,
+  details,
+  title = "Sign Details",
+}) => {
+  return (
+    <ResponsiveDialog open={open} onClose={onClose} hasBackdrop>
+      <DialogHeader
+        title={title}
+        onClose={onClose}
+        className="text-accent-primary"
+      />
+      <DialogBody className="flex flex-col pb-8 pt-4 text-accent-primary gap-4">
+        <div className="border border-secondary-strokeLight p-4 mt-4 bg-primary-contrast/50 rounded max-h-60 overflow-y-auto flex flex-col gap-4">
+          <SignDetails details={details} />
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={onClose}
+          className="flex-1 text-xs sm:text-base"
+        >
+          Close
+        </Button>
+      </DialogFooter>
+    </ResponsiveDialog>
+  );
+};

--- a/src/app/components/Modals/SignModal/SignModal.tsx
+++ b/src/app/components/Modals/SignModal/SignModal.tsx
@@ -8,6 +8,8 @@ import {
 } from "@babylonlabs-io/core-ui";
 
 import { ResponsiveDialog } from "@/app/components/Modals/ResponsiveDialog";
+import { useCosmosWallet } from "@/app/context/wallet/CosmosWalletProvider";
+import { useStakingState } from "@/app/state/StakingState";
 import { getNetworkConfigBBN } from "@/config/network/bbn";
 import { getNetworkConfigBTC } from "@/config/network/btc";
 
@@ -32,62 +34,72 @@ export const SignModal = ({
   step,
   onClose,
   onSubmit,
-}: SignModalProps) => (
-  <ResponsiveDialog open={open} onClose={onClose} hasBackdrop>
-    <DialogHeader
-      title={title}
-      onClose={onClose}
-      className="text-accent-primary"
-    />
+}: SignModalProps) => {
+  const { currentStakingStepOptions } = useStakingState();
+  const { bech32Address } = useCosmosWallet();
 
-    <DialogBody className="flex flex-col pb-8 pt-4 text-accent-primary gap-4">
-      <Text variant="body1" className="text-accent-secondary">
-        Please sign the following messages
-      </Text>
+  // TODO remove
+  console.log("SignModal currentStakingStepOptions", currentStakingStepOptions);
 
-      <div className="py-4 flex flex-col items-start gap-6">
-        <Step step={1} currentStep={step}>
-          Consent to slashing
-        </Step>
-        <Step step={2} currentStep={step}>
-          Consent to slashing during unbonding
-        </Step>
-        <Step step={3} currentStep={step}>
-          {coinSymbol}-{bbnCoinSymbol} address binding for receiving staking
-          rewards
-        </Step>
-        <Step step={4} currentStep={step}>
-          Staking transaction registration
-        </Step>
-      </div>
-    </DialogBody>
+  return (
+    <ResponsiveDialog open={open} onClose={onClose} hasBackdrop>
+      <DialogHeader
+        title={title}
+        onClose={onClose}
+        className="text-accent-primary"
+      />
+      <DialogBody className="flex flex-col pb-8 pt-4 text-accent-primary gap-4">
+        <Text variant="body1" className="text-accent-secondary">
+          Please sign the following messages
+        </Text>
+        <div className="py-4 flex flex-col items-start gap-6">
+          <Step step={1} currentStep={step} details={currentStakingStepOptions}>
+            Consent to slashing
+          </Step>
+          <Step step={2} currentStep={step} details={currentStakingStepOptions}>
+            Consent to slashing during unbonding
+          </Step>
+          <Step
+            step={3}
+            currentStep={step}
+            details={{ address: bech32Address }}
+          >
+            {coinSymbol}-{bbnCoinSymbol} address binding for receiving staking
+            rewards
+          </Step>
+          <Step step={4} currentStep={step}>
+            Staking transaction registration
+          </Step>
+        </div>
+      </DialogBody>
 
-    <DialogFooter className="flex gap-4">
-      {onClose && (
-        <Button
-          variant="outlined"
-          color="primary"
-          onClick={onClose}
-          className="flex-1 text-xs sm:text-base"
-        >
-          Cancel
-        </Button>
-      )}
+      <DialogFooter className="flex gap-4">
+        {onClose && (
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={onClose}
+            className="flex-1 text-xs sm:text-base"
+          >
+            Cancel
+          </Button>
+        )}
 
-      {onSubmit && (
-        <Button
-          disabled={processing}
-          variant="contained"
-          className="flex-1 text-xs sm:text-base"
-          onClick={onSubmit}
-        >
-          {processing ? (
-            <Loader size={16} className="text-accent-contrast" />
-          ) : (
-            "Sign"
-          )}
-        </Button>
-      )}
-    </DialogFooter>
-  </ResponsiveDialog>
-);
+        {onSubmit && (
+          <Button
+            disabled={processing}
+            variant="contained"
+            className="flex-1 text-xs sm:text-base"
+            onClick={onSubmit}
+          >
+            {processing ? (
+              <Loader size={16} className="text-accent-contrast" />
+            ) : (
+              "Sign"
+            )}
+          </Button>
+        )}
+      </DialogFooter>
+    </ResponsiveDialog>
+  );
+};

--- a/src/app/components/Modals/SignModal/Step.tsx
+++ b/src/app/components/Modals/SignModal/Step.tsx
@@ -1,12 +1,17 @@
 import { Loader, Text } from "@babylonlabs-io/core-ui";
-import type { PropsWithChildren, ReactNode } from "react";
+import { SignPsbtOptions } from "@babylonlabs-io/wallet-connector";
+import { PropsWithChildren, ReactNode, useState } from "react";
+import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
 import { IoCheckmarkSharp } from "react-icons/io5";
 import { twMerge } from "tailwind-merge";
+
+import { SignDetails } from "@/app/components/SignDetails/SignDetails";
 
 interface StepProps {
   step: number;
   currentStep: number;
   children: ReactNode;
+  details?: SignPsbtOptions | Record<string, string>;
 }
 
 const renderIcon = (step: number, currentStep: number) => {
@@ -39,17 +44,49 @@ export const Step = ({
   step,
   currentStep,
   children,
-}: PropsWithChildren<StepProps>) => (
-  <div
-    className={twMerge(
-      "p-4 flex flex-row items-center justify-start gap-3 rounded border border-secondary-strokeLight bg-surface self-stretch",
-      step !== currentStep && "opacity-25",
-    )}
-  >
-    {renderIcon(step, currentStep)}
+  details,
+}: PropsWithChildren<StepProps>) => {
+  const [showDetails, setShowDetails] = useState(false);
 
-    <Text variant="body1" className="text-accent-primary">
-      Step {step}: {children}
-    </Text>
-  </div>
-);
+  return (
+    <div className="flex flex-col w-full border border-secondary-strokeLight rounded bg-surface">
+      <div
+        className={twMerge(
+          "p-4 flex flex-row items-center justify-between gap-3 self-stretch",
+          step !== currentStep && "opacity-25",
+        )}
+      >
+        <div className="flex flex-row items-center gap-3">
+          {renderIcon(step, currentStep)}
+          <Text variant="body1" className="text-accent-primary">
+            Step {step}: {children}
+          </Text>
+        </div>
+
+        {step === currentStep && details && (
+          <button
+            className={twMerge(
+              "border border-secondary-strokeLight flex justify-center items-center rounded bg-surface px-4 py-2 gap-1 hover:text-secondary-main cursor-pointer",
+            )}
+            onClick={() => step === currentStep && setShowDetails(!showDetails)}
+          >
+            <div className="hidden md:flex">
+              <Text variant="body2">Details</Text>
+            </div>
+            {showDetails && step === currentStep ? (
+              <AiOutlineMinus size={16} />
+            ) : (
+              <AiOutlinePlus size={16} />
+            )}
+          </button>
+        )}
+      </div>
+
+      {showDetails && details && step === currentStep && (
+        <div className="border border-secondary-strokeLight p-4 mx-4 mb-4 bg-primary-contrast/50 rounded max-h-60 overflow-y-auto flex flex-col gap-4">
+          <SignDetails details={details} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/components/SignDetails/SignDetails.tsx
+++ b/src/app/components/SignDetails/SignDetails.tsx
@@ -1,0 +1,141 @@
+import { Text } from "@babylonlabs-io/core-ui";
+import { SignPsbtOptions } from "@babylonlabs-io/wallet-connector";
+import { ReactNode } from "react";
+
+import { Hash } from "@/app/components/Hash/Hash";
+import { blocksToDisplayTime } from "@/utils/time";
+
+type Details = SignPsbtOptions | Record<string, string>;
+
+interface SignDetailsProps {
+  details: Details;
+}
+
+const keyDisplayMappings: Record<string, string> = {
+  stakerPk: "Staker Public Key",
+  finalityProviders: "Finality Providers",
+  covenantPks: "Covenant Public Keys",
+  covenantThreshold: "Covenant Threshold",
+  minUnbondingTime: "Unbonding Time",
+  stakingDuration: "Staking Duration",
+  unbondingTimeBlocks: "Unbonding Time",
+  address: "Address",
+};
+
+const formatDisplayKey = (key: string): string => {
+  return keyDisplayMappings[key] || key;
+};
+
+const formatContractId = (id: string): string => {
+  if (id.startsWith("babylon:")) {
+    return id
+      .substring("babylon:".length)
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+  }
+  return id;
+};
+
+// Format the display value based on the key and value type
+const formatDisplayValue = (key: string, value: any): ReactNode => {
+  // Staking duration, unbonding time
+  if (
+    typeof value === "number" &&
+    (key.toLowerCase().includes("time") ||
+      key.toLowerCase().includes("duration"))
+  ) {
+    return (
+      <Text
+        variant="body2"
+        className="text-accent-primary break-all text-right"
+      >
+        {blocksToDisplayTime(value)}
+      </Text>
+    );
+  }
+  // Finality providers, covenant public keys
+  if (Array.isArray(value)) {
+    return (
+      <div className="flex flex-col items-end max-w-xs">
+        {value.map((item, index) => (
+          <Hash key={index} value={String(item)} small noFade />
+        ))}
+      </div>
+    );
+  }
+  // Public keys
+  if (typeof value === "string" && key.toLowerCase().includes("pk")) {
+    return <Hash value={value} small noFade />;
+  }
+  // Addresses
+  if (typeof value === "string" && key.toLowerCase().includes("address")) {
+    return <Hash value={value} small noFade address />;
+  }
+  // Default case for other values
+  return (
+    <Text variant="body2" className="text-accent-primary break-all text-right">
+      {String(value)}
+    </Text>
+  );
+};
+
+// Contract details
+const renderContractDetails = (contracts: SignPsbtOptions["contracts"]) => (
+  <>
+    {contracts?.map((contract, contractIndex) => (
+      <div
+        key={`contract-${contractIndex}`}
+        className="flex flex-col gap-4 border-b border-divider pb-4 last:border-b-0 last:pb-0"
+      >
+        <Text
+          variant="body1"
+          className="text-accent-primary font-semibold text-left"
+        >
+          {formatContractId(contract.id)}
+        </Text>
+        {contract.params &&
+          Object.entries(contract.params).map(([key, value]) => (
+            <div key={key} className="flex justify-between items-start gap-2">
+              <Text
+                variant="body2"
+                className="text-accent-secondary whitespace-nowrap"
+              >
+                {formatDisplayKey(key)}:
+              </Text>
+              {formatDisplayValue(key, value)}
+            </div>
+          ))}
+      </div>
+    ))}
+  </>
+);
+
+// Generic details, like { address: "babyAddress" }
+const renderObjectDetails = (details: Record<string, string>) => (
+  <>
+    {Object.entries(details).map(([key, value]) => (
+      <div key={key} className="flex justify-between items-start gap-2">
+        <Text
+          variant="body2"
+          className="text-accent-secondary whitespace-nowrap"
+        >
+          {formatDisplayKey(key)}:
+        </Text>
+        {formatDisplayValue(key, value)}
+      </div>
+    ))}
+  </>
+);
+
+export const SignDetails: React.FC<SignDetailsProps> = ({ details }) => {
+  // Contracts details
+  if (details && "contracts" in details && Array.isArray(details.contracts)) {
+    return renderContractDetails(details.contracts);
+  }
+  // Object details, like { address: "babyAddress" }
+  if (typeof details === "object" && details !== null) {
+    return renderObjectDetails(details as Record<string, string>);
+  }
+  return null;
+};

--- a/src/app/components/SignDetails/SignDetails.tsx
+++ b/src/app/components/SignDetails/SignDetails.tsx
@@ -59,14 +59,14 @@ const formatDisplayValue = (key: string, value: any): ReactNode => {
     return (
       <div className="flex flex-col items-end max-w-xs">
         {value.map((item, index) => (
-          <Hash key={index} value={String(item)} small noFade />
+          <Hash key={index} value={String(item)} small noFade address />
         ))}
       </div>
     );
   }
   // Public keys
   if (typeof value === "string" && key.toLowerCase().includes("pk")) {
-    return <Hash value={value} small noFade />;
+    return <Hash value={value} small noFade address />;
   }
   // Addresses
   if (typeof value === "string" && key.toLowerCase().includes("address")) {

--- a/src/app/hooks/services/useDelegationService.ts
+++ b/src/app/hooks/services/useDelegationService.ts
@@ -274,6 +274,8 @@ export function useDelegationService() {
   useEffect(() => {
     const unsubscribe = subscribeToSigningSteps(
       (_step: SigningStep, options?: SignPsbtOptions) => {
+        // TODO remove
+        console.log("useDelegationService", _step, options);
         setCurrentStepOptions(options);
       },
     );

--- a/src/app/hooks/services/useRegistrationService.ts
+++ b/src/app/hooks/services/useRegistrationService.ts
@@ -64,6 +64,8 @@ export function useRegistrationService() {
   useEffect(() => {
     const unsubscribe = subscribeToSigningSteps(
       (step: SigningStep, options?: SignPsbtOptions) => {
+        // TODO remove
+        console.log("useTransactionService", step, options);
         const stepName = REGISTRATION_STEP_MAP[step as RegistrationSigningStep];
         if (stepName) {
           setStep(stepName, options);

--- a/src/app/hooks/services/useStakingService.ts
+++ b/src/app/hooks/services/useStakingService.ts
@@ -59,18 +59,34 @@ export function useStakingService() {
   const { bech32Address } = useCosmosWallet();
   const logger = useLogger();
 
+  // TODO remove
+  const { setCurrentStepOptions } = useDelegationV2State();
+
   useEffect(() => {
     const unsubscribe = subscribeToSigningSteps(
       (step: SigningStep, options?: SignPsbtOptions) => {
+        // TODO remove
+        console.log("useStakingService", step, options);
         const stepName = STAKING_SIGNING_STEP_MAP[step as StakingSigningStep];
         if (stepName) {
+          // This is not called for the "staking" transaction after the EOI
+          // even though it will trigger the subscription
           goToStep(stepName, options);
+        }
+        // TODO remove using the proper event emitter
+        if (step === SigningStep.STAKING) {
+          setCurrentStepOptions(options);
         }
       },
     );
 
     return unsubscribe;
-  }, [subscribeToSigningSteps, goToStep]);
+  }, [
+    subscribeToSigningSteps,
+    goToStep,
+    // TODO remove
+    setCurrentStepOptions,
+  ]);
 
   const calculateFeeAmount = ({
     finalityProvider,

--- a/src/app/state/DelegationState.tsx
+++ b/src/app/state/DelegationState.tsx
@@ -45,6 +45,8 @@ interface DelegationState {
   setSelectedDelegation: (delegation?: Delegation) => void;
   resetRegistration: () => void;
   refetch: () => void;
+  setCurrentDelegationStepOptions: (options?: SignPsbtOptions) => void;
+  currentDelegationStepOptions?: SignPsbtOptions;
 }
 
 const { StateProvider, useState: useDelegationState } =
@@ -62,6 +64,8 @@ const { StateProvider, useState: useDelegationState } =
     setSelectedDelegation: () => null,
     resetRegistration: () => null,
     refetch: () => null,
+    setCurrentDelegationStepOptions: () => null,
+    currentDelegationStepOptions: undefined,
   });
 
 export function DelegationState({ children }: PropsWithChildren) {

--- a/src/app/state/DelegationV2State.tsx
+++ b/src/app/state/DelegationV2State.tsx
@@ -27,6 +27,7 @@ interface DelegationV2State {
   refetch: () => void;
   displayLinkedDelegations: (value: boolean) => void;
   setCurrentStepOptions: (options?: SignPsbtOptions) => void;
+  currentStepOptions?: SignPsbtOptions;
 }
 
 const { StateProvider, useState: useDelegationV2State } =
@@ -43,6 +44,7 @@ const { StateProvider, useState: useDelegationV2State } =
     refetch: () => Promise.resolve(),
     displayLinkedDelegations: () => {},
     setCurrentStepOptions: () => {},
+    currentStepOptions: undefined,
   });
 
 export function DelegationV2State({ children }: PropsWithChildren) {

--- a/src/components/staking/StakingModal/index.tsx
+++ b/src/components/staking/StakingModal/index.tsx
@@ -8,6 +8,7 @@ import { StakeModal } from "@/app/components/Modals/StakeModal";
 import { SuccessFeedbackModal } from "@/app/components/Modals/SuccessFeedbackModal";
 import { VerificationModal } from "@/app/components/Modals/VerificationModal";
 import { useStakingService } from "@/app/hooks/services/useStakingService";
+import { useDelegationV2State } from "@/app/state/DelegationV2State";
 import { useFinalityProviderState } from "@/app/state/FinalityProviderState";
 import { useStakingState } from "@/app/state/StakingState";
 
@@ -32,6 +33,7 @@ export function StakingModal() {
     verifiedDelegation,
     reset: resetState,
   } = useStakingState();
+  const { setCurrentStepOptions } = useDelegationV2State();
   const { getRegisteredFinalityProvider } = useFinalityProviderState();
   const { createEOI, stakeDelegation } = useStakingService();
   const {
@@ -102,16 +104,26 @@ export function StakingModal() {
           open={step === "verified"}
           processing={processing}
           onSubmit={() => stakeDelegation(verifiedDelegation)}
-          onClose={resetState}
+          onClose={() => {
+            resetState();
+            // TODO this is wrong because we mix staking state and delegation state
+            setCurrentStepOptions(undefined);
+          }}
         />
       )}
       <SuccessFeedbackModal
         open={step === "feedback-success"}
-        onClose={resetState}
+        onClose={() => {
+          resetState();
+          setCurrentStepOptions(undefined);
+        }}
       />
       <CancelFeedbackModal
         open={step === "feedback-cancel"}
-        onClose={resetState}
+        onClose={() => {
+          resetState();
+          setCurrentStepOptions(undefined);
+        }}
       />
     </>
   );


### PR DESCRIPTION
This PR relies on the #1079 for the cleaner data setting as
- staking after the EOI will cause the `stake event` to set the options for the `staking state`
- while closing this modal and clicking the `stake` button in `Delegations` component will cause setting the `delegation v2 state`

---

TODOs

- data flow on a proper emitter
- details to receive headers and array of key / value pairs instead of `SignPsbtOptions | something`

---

Closes #929