### PR TITLE
fix: babylon client

### DIFF
--- a/src/infrastructure/babylon.ts
+++ b/src/infrastructure/babylon.ts
@@ -1,0 +1,20 @@
+import {
+  BabylonClient,
+  type BabylonClientConfig,
+} from "@babylonlabs-io/babylon-proto-ts";
+
+export default ({ config }: DI.Container) => {
+  const babylonConfig: BabylonClientConfig = {
+    rpc: config.babylon.rpc,
+  };
+
+  // Create read-only client for queries
+  const createBabylonClient = async (): Promise<BabylonClient> => {
+    return await BabylonClient.connect(babylonConfig);
+  };
+
+  return {
+    createBabylonClient,
+    config: babylonConfig,
+  };
+};

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -8,4 +8,9 @@ export default {
     url: process.env.NEXT_PUBLIC_MEMPOOL_API ?? "https://mempool.space",
     network: process.env.NEXT_PUBLIC_NETWORK ?? "signet",
   },
+  babylon: {
+    rpc:
+      process.env.NEXT_PUBLIC_BABY_RPC_URL ??
+      "https://rpc-dapp.devnet.babylonlabs.io/",
+  },
 } satisfies Infra.Config;

--- a/src/types/infrastructure/config.d.ts
+++ b/src/types/infrastructure/config.d.ts
@@ -7,6 +7,9 @@ namespace Infra {
       url: string;
       network: string;
     };
+    babylon: {
+      rpc: string;
+    };
   }
 }
 


### PR DESCRIPTION
Adds support of Babylon Client.
All the `protobuf` imports from `@babylonlabs-io/babylon-proto-ts` can now be removed and only `import { BabylonClient } from "@babylonlabs-io/babylon-proto-ts"` to be used