### PR TITLE
chore: BABY Staking MVP

### DIFF
--- a/src/ui/baby/index.tsx
+++ b/src/ui/baby/index.tsx
@@ -1,9 +1,369 @@
+import { useState } from "react";
+
+import { useCosmosWallet } from "@/ui/legacy/context/wallet/CosmosWalletProvider";
+import { useBbnQuery } from "@/ui/legacy/hooks/client/rpc/queries/useBbnQuery";
+import { useEpochingService } from "@/ui/legacy/hooks/services/useEpochingService";
 import Layout from "@/ui/legacy/layout";
+import { babyToUbbn, ubbnToBaby } from "@/ui/legacy/utils/bbn";
 
 export default function BabyStaking() {
+  const { bech32Address, connected } = useCosmosWallet();
+  const { stake, unstake, claimRewards } = useEpochingService();
+  const { delegationsQuery, delegationRewardsQuery, validatorsQuery } =
+    useBbnQuery();
+
+  const [validatorAddress, setValidatorAddress] = useState("");
+  const [stakeAmount, setStakeAmount] = useState("");
+  const [unstakeAmount, setUnstakeAmount] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const delegations = delegationsQuery.data || [];
+  const rewards = delegationRewardsQuery.data || [];
+  const validators = validatorsQuery.data || [];
+
+  // Helper function to get rewards for a specific validator
+  const getRewardsForValidator = (validatorAddress: string): number => {
+    const validatorReward = rewards.find(
+      (reward) => reward.validatorAddress === validatorAddress,
+    );
+    if (!validatorReward?.reward) return 0;
+
+    return validatorReward.reward.reduce((total, coin) => {
+      if (coin.denom === "ubbn") {
+        return total + ubbnToBaby(parseFloat(coin.amount));
+      }
+      return total;
+    }, 0);
+  };
+
+  const totalStaked = delegations.reduce((total, delegation) => {
+    if (delegation.balance?.denom === "ubbn") {
+      return total + ubbnToBaby(parseFloat(delegation.balance.amount));
+    }
+    return total;
+  }, 0);
+
+  const totalRewards = rewards.reduce((total, reward) => {
+    return (
+      total +
+      (reward.reward || []).reduce((acc, coin) => {
+        if (coin.denom === "ubbn") {
+          return acc + ubbnToBaby(parseFloat(coin.amount));
+        }
+        return acc;
+      }, 0)
+    );
+  }, 0);
+
+  const handleStake = async () => {
+    if (!validatorAddress || !stakeAmount) return;
+
+    const tbabyAmount = parseFloat(stakeAmount);
+    if (isNaN(tbabyAmount) || tbabyAmount <= 0) {
+      alert("Please enter a valid amount");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const ubbnAmount = babyToUbbn(tbabyAmount);
+      await stake(bech32Address, validatorAddress, {
+        denom: "ubbn",
+        amount: ubbnAmount.toString(),
+      });
+      alert(`Successfully staked ${tbabyAmount} tBABY!`);
+      await delegationsQuery.refetch();
+      await delegationRewardsQuery.refetch();
+      setStakeAmount("");
+    } catch (error: any) {
+      alert(`Staking failed: ${error.message || "Unknown error"}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUnstake = async () => {
+    if (!validatorAddress || !unstakeAmount) return;
+
+    const tbabyAmount = parseFloat(unstakeAmount);
+    if (isNaN(tbabyAmount) || tbabyAmount <= 0) {
+      alert("Please enter a valid amount");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const ubbnAmount = babyToUbbn(tbabyAmount);
+      await unstake(bech32Address, validatorAddress, {
+        denom: "ubbn",
+        amount: ubbnAmount.toString(),
+      });
+      alert(`Successfully unstaked ${tbabyAmount} tBABY!`);
+      await delegationsQuery.refetch();
+      await delegationRewardsQuery.refetch();
+      setUnstakeAmount("");
+    } catch (error: any) {
+      alert(`Unstaking failed: ${error.message || "Unknown error"}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClaimRewards = async () => {
+    if (!validatorAddress) return;
+
+    setLoading(true);
+    try {
+      await claimRewards(bech32Address, validatorAddress);
+      await delegationRewardsQuery.refetch();
+      alert("Rewards claimed successfully!");
+    } catch (error: any) {
+      alert(`Failed to claim rewards: ${error.message || "Unknown error"}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!connected) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center h-96">
+          <div className="text-center">
+            <h2 className="text-2xl font-bold mb-4">Connect Your Wallet</h2>
+            <p className="text-gray-600">
+              Please connect your Babylon wallet to use staking features.
+            </p>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
   return (
     <Layout>
-      <div className="h-[500px]">Baby staking</div>
+      <div className="container mx-auto p-6 max-w-4xl">
+        <h1 className="text-3xl font-bold mb-8 text-center">Baby Staking</h1>
+
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <h2 className="text-xl font-semibold mb-4">Wallet Info</h2>
+          <p className="text-sm text-gray-600 mb-2">Address: {bech32Address}</p>
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div>
+              <p className="text-sm font-medium">Active Delegations</p>
+              <p className="text-lg font-bold">{delegations.length}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium">Total Staked</p>
+              <p className="text-lg font-bold">
+                {totalStaked.toLocaleString()} tBABY
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium">Total Rewards</p>
+              <p className="text-lg font-bold text-green-600">
+                {totalRewards.toLocaleString()} tBABY
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium">Available Validators</p>
+              <p className="text-lg font-bold">{validators.length}</p>
+            </div>
+          </div>
+        </div>
+
+        {delegations.length > 0 && (
+          <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+            <h2 className="text-xl font-semibold mb-4">My Delegations</h2>
+            <div className="space-y-2">
+              {delegations.map((delegation, index) => {
+                const validatorAddress =
+                  delegation.delegation?.validatorAddress || "";
+                const stakedAmount = ubbnToBaby(
+                  parseFloat(delegation.balance?.amount || "0"),
+                );
+                const rewardsAmount = getRewardsForValidator(validatorAddress);
+
+                return (
+                  <div
+                    key={index}
+                    className="flex justify-between items-center p-3 border rounded"
+                  >
+                    <div>
+                      <p className="font-medium">
+                        {validators.find(
+                          (v) => v.operatorAddress === validatorAddress,
+                        )?.description?.moniker || validatorAddress}
+                      </p>
+                      <p className="text-sm text-gray-600">
+                        Staked: {stakedAmount.toLocaleString()} tBABY
+                      </p>
+                      {rewardsAmount > 0 && (
+                        <p className="text-sm text-green-600">
+                          Rewards: {rewardsAmount.toLocaleString()} tBABY
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => {
+                          setValidatorAddress(validatorAddress);
+                          setUnstakeAmount(stakedAmount.toString());
+                        }}
+                        className="px-3 py-1 bg-red-500 text-white text-sm rounded hover:bg-red-600"
+                      >
+                        Unstake All
+                      </button>
+                      {rewardsAmount > 0 && (
+                        <button
+                          onClick={async () => {
+                            setValidatorAddress(validatorAddress);
+                            await handleClaimRewards();
+                          }}
+                          disabled={loading}
+                          className="px-3 py-1 bg-green-500 text-white text-sm rounded hover:bg-green-600 disabled:bg-gray-300"
+                        >
+                          {loading ? "Claiming..." : "Claim"}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {/* Stake Section */}
+          <div className="bg-white rounded-lg shadow-md p-6">
+            <h2 className="text-xl font-semibold mb-4">Stake</h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Validator
+                </label>
+                <select
+                  value={validatorAddress}
+                  onChange={(e) => setValidatorAddress(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="">Select a validator</option>
+                  {validators.map((validator) => (
+                    <option
+                      key={validator.operatorAddress}
+                      value={validator.operatorAddress}
+                    >
+                      {validator.description?.moniker ||
+                        validator.operatorAddress}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Amount (tBABY)
+                </label>
+                <input
+                  type="text"
+                  value={stakeAmount}
+                  onChange={(e) => setStakeAmount(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="Enter tBABY amount to stake (e.g., 10)"
+                />
+              </div>
+              <button
+                onClick={handleStake}
+                disabled={loading || !validatorAddress || !stakeAmount}
+                className="w-full bg-blue-500 text-white py-2 px-4 rounded-md hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+              >
+                {loading ? "Staking..." : "Stake tBABY"}
+              </button>
+            </div>
+          </div>
+
+          {/* Unstake Section */}
+          <div className="bg-white rounded-lg shadow-md p-6">
+            <h2 className="text-xl font-semibold mb-4">Unstake</h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Validator
+                </label>
+                <select
+                  value={validatorAddress}
+                  onChange={(e) => setValidatorAddress(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                >
+                  <option value="">Select a validator</option>
+                  {validators.map((validator) => (
+                    <option
+                      key={validator.operatorAddress}
+                      value={validator.operatorAddress}
+                    >
+                      {validator.description?.moniker ||
+                        validator.operatorAddress}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Amount (tBABY)
+                </label>
+                <input
+                  type="text"
+                  value={unstakeAmount}
+                  onChange={(e) => setUnstakeAmount(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                  placeholder="Enter tBABY amount to unstake (e.g., 5)"
+                />
+              </div>
+              <button
+                onClick={handleUnstake}
+                disabled={loading || !validatorAddress || !unstakeAmount}
+                className="w-full bg-red-500 text-white py-2 px-4 rounded-md hover:bg-red-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+              >
+                {loading ? "Unstaking..." : "Unstake tBABY"}
+              </button>
+            </div>
+          </div>
+
+          {/* Rewards Section */}
+          <div className="bg-white rounded-lg shadow-md p-6">
+            <h2 className="text-xl font-semibold mb-4">Rewards</h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Validator
+                </label>
+                <select
+                  value={validatorAddress}
+                  onChange={(e) => setValidatorAddress(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+                >
+                  <option value="">Select a validator</option>
+                  {validators.map((validator) => (
+                    <option
+                      key={validator.operatorAddress}
+                      value={validator.operatorAddress}
+                    >
+                      {validator.description?.moniker ||
+                        validator.operatorAddress}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                onClick={handleClaimRewards}
+                disabled={loading || !validatorAddress}
+                className="w-full bg-green-500 text-white py-2 px-4 rounded-md hover:bg-green-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+              >
+                {loading ? "Claiming..." : "Claim Rewards"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 }

--- a/src/ui/legacy/hooks/services/useEpochingService.ts
+++ b/src/ui/legacy/hooks/services/useEpochingService.ts
@@ -1,0 +1,262 @@
+import { epochingtx } from "@babylonlabs-io/babylon-proto-ts";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
+import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+import { useCallback } from "react";
+
+import { useError } from "@/ui/legacy/context/Error/ErrorProvider";
+import { useLogger } from "@/ui/legacy/hooks/useLogger";
+import { BBN_REGISTRY_TYPE_URLS } from "@/ui/legacy/utils/wallet/bbnRegistry";
+
+import { useBbnTransaction } from "../client/rpc/mutation/useBbnTransaction";
+
+export const useEpochingService = () => {
+  const { handleError } = useError();
+  const logger = useLogger();
+  const { estimateBbnGasFee, sendBbnTx, signBbnTx } = useBbnTransaction();
+
+  /**
+   * Estimates the gas fee for BABY staking.
+   * @param delegatorAddress - The delegator address
+   * @param validatorAddress - The validator address
+   * @param amount - The amount to stake
+   * @returns The gas fee for staking
+   */
+  const estimateStakeGas = useCallback(
+    async (
+      delegatorAddress: string,
+      validatorAddress: string,
+      amount: Coin,
+    ): Promise<number> => {
+      const stakeMsg = createStakeMsg(
+        delegatorAddress,
+        validatorAddress,
+        amount,
+      );
+      const gasFee = await estimateBbnGasFee(stakeMsg);
+      return gasFee.amount.reduce((acc, coin) => acc + Number(coin.amount), 0);
+    },
+    [estimateBbnGasFee],
+  );
+
+  /**
+   * Estimates the gas fee for unstaking.
+   * @param delegatorAddress - The delegator address
+   * @param validatorAddress - The validator address
+   * @param amount - The amount to unstake
+   * @returns The gas fee for unstaking
+   */
+  const estimateUnstakeGas = useCallback(
+    async (
+      delegatorAddress: string,
+      validatorAddress: string,
+      amount: Coin,
+    ): Promise<number> => {
+      const unstakeMsg = createUnstakeMsg(
+        delegatorAddress,
+        validatorAddress,
+        amount,
+      );
+      const gasFee = await estimateBbnGasFee(unstakeMsg);
+      return gasFee.amount.reduce((acc, coin) => acc + Number(coin.amount), 0);
+    },
+    [estimateBbnGasFee],
+  );
+
+  /**
+   * Estimates the gas fee for claiming rewards.
+   * @param delegatorAddress - The delegator address
+   * @param validatorAddress - The validator address
+   * @returns The gas fee for claiming rewards
+   */
+  const estimateClaimRewardsGas = useCallback(
+    async (
+      delegatorAddress: string,
+      validatorAddress: string,
+    ): Promise<number> => {
+      const claimMsg = createClaimRewardsMsg(
+        delegatorAddress,
+        validatorAddress,
+      );
+      const gasFee = await estimateBbnGasFee(claimMsg);
+      return gasFee.amount.reduce((acc, coin) => acc + Number(coin.amount), 0);
+    },
+    [estimateBbnGasFee],
+  );
+
+  /**
+   * Stakes tokens with a validator.
+   * @param delegatorAddress - The delegator address
+   * @param validatorAddress - The validator address
+   * @param amount - The amount to stake
+   * @returns The transaction result
+   */
+  const stake = useCallback(
+    async (
+      delegatorAddress: string,
+      validatorAddress: string,
+      amount: Coin,
+    ) => {
+      try {
+        const msg = createStakeMsg(delegatorAddress, validatorAddress, amount);
+        const signedTx = await signBbnTx(msg);
+        const result = await sendBbnTx(signedTx);
+
+        logger.info("Stake transaction completed", {
+          txHash: result?.txHash,
+        });
+
+        return result;
+      } catch (error: any) {
+        logger.error(error);
+        handleError({ error });
+        throw error;
+      }
+    },
+    [signBbnTx, sendBbnTx, logger, handleError],
+  );
+
+  /**
+   * Unstakes tokens from a validator.
+   * @param delegatorAddress - The delegator address
+   * @param validatorAddress - The validator address
+   * @param amount - The amount to unstake
+   * @returns The transaction result
+   */
+  const unstake = useCallback(
+    async (
+      delegatorAddress: string,
+      validatorAddress: string,
+      amount: Coin,
+    ) => {
+      try {
+        const msg = createUnstakeMsg(
+          delegatorAddress,
+          validatorAddress,
+          amount,
+        );
+        const signedTx = await signBbnTx(msg);
+        const result = await sendBbnTx(signedTx);
+
+        logger.info("Unstake transaction completed", {
+          txHash: result?.txHash,
+        });
+
+        return result;
+      } catch (error: any) {
+        logger.error(error);
+        handleError({ error });
+        throw error;
+      }
+    },
+    [signBbnTx, sendBbnTx, logger, handleError],
+  );
+
+  /**
+   * Claims rewards from a validator.
+   * @param delegatorAddress - The delegator address
+   * @param validatorAddress - The validator address
+   * @returns The transaction result
+   */
+  const claimRewards = useCallback(
+    async (delegatorAddress: string, validatorAddress: string) => {
+      try {
+        const msg = createClaimRewardsMsg(delegatorAddress, validatorAddress);
+        const signedTx = await signBbnTx(msg);
+        const result = await sendBbnTx(signedTx);
+
+        logger.info("Claim rewards transaction completed", {
+          txHash: result?.txHash,
+        });
+
+        return result;
+      } catch (error: any) {
+        logger.error(error);
+        handleError({ error });
+        throw error;
+      }
+    },
+    [signBbnTx, sendBbnTx, logger, handleError],
+  );
+
+  return {
+    stake,
+    unstake,
+    claimRewards,
+    estimateStakeGas,
+    estimateUnstakeGas,
+    estimateClaimRewardsGas,
+  };
+};
+
+/**
+ * Creates a wrapped delegate message for staking.
+ * @param delegatorAddress - The delegator address
+ * @param validatorAddress - The validator address
+ * @param amount - The amount to stake
+ * @returns The wrapped delegate message
+ */
+const createStakeMsg = (
+  delegatorAddress: string,
+  validatorAddress: string,
+  amount: Coin,
+) => {
+  const wrappedDelegateMsg = epochingtx.MsgWrappedDelegate.fromPartial({
+    msg: {
+      delegatorAddress,
+      validatorAddress,
+      amount,
+    },
+  });
+
+  return {
+    typeUrl: BBN_REGISTRY_TYPE_URLS.MsgWrappedDelegate,
+    value: wrappedDelegateMsg,
+  };
+};
+
+/**
+ * Creates a wrapped undelegate message for unstaking.
+ * @param delegatorAddress - The delegator address
+ * @param validatorAddress - The validator address
+ * @param amount - The amount to unstake
+ * @returns The wrapped undelegate message
+ */
+const createUnstakeMsg = (
+  delegatorAddress: string,
+  validatorAddress: string,
+  amount: Coin,
+) => {
+  const wrappedUndelegateMsg = epochingtx.MsgWrappedUndelegate.fromPartial({
+    msg: {
+      delegatorAddress,
+      validatorAddress,
+      amount,
+    },
+  });
+
+  return {
+    typeUrl: BBN_REGISTRY_TYPE_URLS.MsgWrappedUndelegate,
+    value: wrappedUndelegateMsg,
+  };
+};
+
+/**
+ * Creates a withdraw delegator reward message for claiming rewards.
+ * @param delegatorAddress - The delegator address
+ * @param validatorAddress - The validator address
+ * @returns The withdraw delegator reward message
+ */
+const createClaimRewardsMsg = (
+  delegatorAddress: string,
+  validatorAddress: string,
+) => {
+  const withdrawRewardMsg = MsgWithdrawDelegatorReward.fromPartial({
+    delegatorAddress,
+    validatorAddress,
+  });
+
+  return {
+    typeUrl: BBN_REGISTRY_TYPE_URLS.MsgWithdrawDelegatorReward,
+    value: withdrawRewardMsg,
+  };
+};

--- a/src/ui/legacy/utils/bbn.ts
+++ b/src/ui/legacy/utils/bbn.ts
@@ -1,3 +1,5 @@
+import { QueryDelegationTotalRewardsResponse } from "cosmjs-types/cosmos/distribution/v1beta1/query";
+
 /**
  * Converts BABY to uBBN (micro BABY).
  * should be used internally in the app
@@ -16,4 +18,33 @@ export function babyToUbbn(bbn: number): number {
  */
 export function ubbnToBaby(ubbn: number): number {
   return ubbn / 1e6;
+}
+
+/**
+ * Normalizes CosmJS amount from 18-decimal precision to standard ubbn format.
+ * CosmJS returns amounts with 18 decimal places, but standard ubbn format uses fewer decimals.
+ * @param amount The amount string from CosmJS (with 18 decimal precision).
+ * @returns The normalized amount as a string in standard ubbn format.
+ */
+export function normalizeCosmjsAmount(amount: string): string {
+  const numAmount = parseFloat(amount);
+  return (numAmount / 1e18).toString();
+}
+
+/**
+ * Normalizes reward response from CosmJS to standard ubbn format.
+ * Applies amount normalization to all coin amounts in the reward structure.
+ * @param response The QueryDelegationTotalRewardsResponse from CosmJS.
+ * @returns The normalized reward array with amounts in standard ubbn format.
+ */
+export function normalizeRewardResponse(
+  response: QueryDelegationTotalRewardsResponse,
+) {
+  return response.rewards?.map((reward) => ({
+    ...reward,
+    reward: reward.reward?.map((coin) => ({
+      ...coin,
+      amount: normalizeCosmjsAmount(coin.amount),
+    })),
+  }));
 }

--- a/src/ui/legacy/utils/wallet/amino.ts
+++ b/src/ui/legacy/utils/wallet/amino.ts
@@ -1,10 +1,16 @@
-import { btcstakingtx, incentivetx } from "@babylonlabs-io/babylon-proto-ts";
+import {
+  btcstakingtx,
+  epochingtx,
+  incentivetx,
+} from "@babylonlabs-io/babylon-proto-ts";
 import { AminoTypes } from "@cosmjs/stargate";
+import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
 
 import { ClientError, ERROR_CODES } from "@/ui/legacy/errors";
 
 import { BBN_REGISTRY_TYPE_URLS } from "./bbnRegistry";
 
+// BTC Staking
 const msgCreateBTCDelegationConverter = {
   [BBN_REGISTRY_TYPE_URLS.MsgCreateBTCDelegation]: {
     aminoType: BBN_REGISTRY_TYPE_URLS.MsgCreateBTCDelegation,
@@ -107,6 +113,7 @@ const msgCreateBTCDelegationConverter = {
   },
 };
 
+// Incentives - Claiming BABY rewards from BTC Staking
 const msgWithdrawRewardConverter = {
   [BBN_REGISTRY_TYPE_URLS.MsgWithdrawReward]: {
     aminoType: BBN_REGISTRY_TYPE_URLS.MsgWithdrawReward,
@@ -125,9 +132,81 @@ const msgWithdrawRewardConverter = {
   },
 };
 
+// Epoching - Staking BABY
+const msgWrappedDelegateConverter = {
+  [BBN_REGISTRY_TYPE_URLS.MsgWrappedDelegate]: {
+    aminoType: BBN_REGISTRY_TYPE_URLS.MsgWrappedDelegate,
+    toAmino: (msg: epochingtx.MsgWrappedDelegate) => {
+      return {
+        msg: {
+          delegator_address: msg.msg?.delegatorAddress,
+          validator_address: msg.msg?.validatorAddress,
+          amount: msg.msg?.amount,
+        },
+      };
+    },
+    fromAmino: (json: any): epochingtx.MsgWrappedDelegate => {
+      return {
+        msg: {
+          delegatorAddress: json.msg.delegator_address,
+          validatorAddress: json.msg.validator_address,
+          amount: json.msg.amount,
+        },
+      };
+    },
+  },
+};
+
+// Epoching - Unstaking BABY
+const msgWrappedUndelegateConverter = {
+  [BBN_REGISTRY_TYPE_URLS.MsgWrappedUndelegate]: {
+    aminoType: BBN_REGISTRY_TYPE_URLS.MsgWrappedUndelegate,
+    toAmino: (msg: epochingtx.MsgWrappedUndelegate) => {
+      return {
+        msg: {
+          delegator_address: msg.msg?.delegatorAddress,
+          validator_address: msg.msg?.validatorAddress,
+          amount: msg.msg?.amount,
+        },
+      };
+    },
+    fromAmino: (json: any): epochingtx.MsgWrappedUndelegate => {
+      return {
+        msg: {
+          delegatorAddress: json.msg.delegator_address,
+          validatorAddress: json.msg.validator_address,
+          amount: json.msg.amount,
+        },
+      };
+    },
+  },
+};
+
+// Cosmos Distribution - Claiming BABY rewards from BABY Staking
+const msgWithdrawDelegatorRewardConverter = {
+  [BBN_REGISTRY_TYPE_URLS.MsgWithdrawDelegatorReward]: {
+    aminoType: BBN_REGISTRY_TYPE_URLS.MsgWithdrawDelegatorReward,
+    toAmino: (msg: MsgWithdrawDelegatorReward) => {
+      return {
+        delegator_address: msg.delegatorAddress,
+        validator_address: msg.validatorAddress,
+      };
+    },
+    fromAmino: (json: any): MsgWithdrawDelegatorReward => {
+      return {
+        delegatorAddress: json.delegator_address,
+        validatorAddress: json.validator_address,
+      };
+    },
+  },
+};
+
 export const bbnAminoConverters = {
   ...msgCreateBTCDelegationConverter,
   ...msgWithdrawRewardConverter,
+  ...msgWrappedDelegateConverter,
+  ...msgWrappedUndelegateConverter,
+  ...msgWithdrawDelegatorRewardConverter,
 };
 
 export function createBbnAminoTypes(): AminoTypes {

--- a/src/ui/legacy/utils/wallet/bbnRegistry.ts
+++ b/src/ui/legacy/utils/wallet/bbnRegistry.ts
@@ -1,6 +1,11 @@
-import { btcstakingtx, incentivetx } from "@babylonlabs-io/babylon-proto-ts";
+import {
+  btcstakingtx,
+  epochingtx,
+  incentivetx,
+} from "@babylonlabs-io/babylon-proto-ts";
 import { MessageFns } from "@babylonlabs-io/babylon-proto-ts/dist/generated/google/protobuf/any";
 import { GeneratedType, Registry } from "@cosmjs/proto-signing";
+import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
 
 // Define the structure of each proto to register
 type ProtoToRegister<T> = {
@@ -11,6 +16,10 @@ type ProtoToRegister<T> = {
 export const BBN_REGISTRY_TYPE_URLS = {
   MsgCreateBTCDelegation: "/babylon.btcstaking.v1.MsgCreateBTCDelegation",
   MsgWithdrawReward: "/babylon.incentive.MsgWithdrawReward",
+  MsgWrappedDelegate: "/babylon.epoching.v1.MsgWrappedDelegate",
+  MsgWrappedUndelegate: "/babylon.epoching.v1.MsgWrappedUndelegate",
+  MsgWithdrawDelegatorReward:
+    "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
 };
 
 // List of protos to register in the registry
@@ -20,10 +29,24 @@ const protosToRegister: ProtoToRegister<any>[] = [
     typeUrl: BBN_REGISTRY_TYPE_URLS.MsgCreateBTCDelegation,
     messageType: btcstakingtx.MsgCreateBTCDelegation,
   },
-  // Incentives
+  // Incentives - Claiming BABY rewards from BTC Staking
   {
     typeUrl: BBN_REGISTRY_TYPE_URLS.MsgWithdrawReward,
     messageType: incentivetx.MsgWithdrawReward,
+  },
+  // Epoching - Staking / Unstaking BABY
+  {
+    typeUrl: BBN_REGISTRY_TYPE_URLS.MsgWrappedDelegate,
+    messageType: epochingtx.MsgWrappedDelegate,
+  },
+  {
+    typeUrl: BBN_REGISTRY_TYPE_URLS.MsgWrappedUndelegate,
+    messageType: epochingtx.MsgWrappedUndelegate,
+  },
+  // Cosmos Distribution - Claiming rewards from BABY Staking
+  {
+    typeUrl: BBN_REGISTRY_TYPE_URLS.MsgWithdrawDelegatorReward,
+    messageType: MsgWithdrawDelegatorReward as any,
   },
 ];
 


### PR DESCRIPTION
# Baby Staking MVP Implementation

This PR introduces a simplified MVP implementation of Baby (tBABY) staking functionality

- **Direct tBABY Staking**: Stake/unstake tBABY tokens with Babylon validators
- **Real-time Delegation Management**: View active delegations with staked amounts
- **Per-Validator Rewards**: See claimable rewards and claim with one click
- **Simplified UI**: Basic forms and lists for quick testing and validation

Files:
- `src/ui/baby/index.tsx` - composition of simple components to work with BABY staking <- to be replaced with real components
- `src/ui/common/hooks/client/rpc/queries/useBbnQuery.ts` - Added BABY staking queries @0xDazzer 
  - get `delegations`
  - get `rewards`
  - get `vaidators`
- `src/ui/common/hooks/services/useEpochingService.ts` <- @0xDazzer 
  - `stake`, `unstake`, `claim` actions
  - `createStakeMsg`, `createUnstakeMsg`, `createClaimRewardsMsg`
  - estimate gas for `stake`, `unstake`, `unbond`
- `src/ui/common/utils/bbn.ts` - `CosmJS` right now is using `wei` precision for the rewards, so we need to cut `1e18` before we can use a proper `ubbn` amounts. This might be removed in the future if we find a way to solve this (via `CosmJS` config or so)
- `src/ui/common/utils/wallet/bbnRegistry.ts` - New transactions registry updates
- `src/ui/common/utils/wallet/amino.ts` - Conversion to `amino` for Hardware wallets