### PR TITLE
feat: bump wallet connector to 1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@babylonlabs-io/babylon-proto-ts": "1.1.0",
         "@babylonlabs-io/btc-staking-ts": "2.3.4",
         "@babylonlabs-io/core-ui": "1.4.1",
-        "@babylonlabs-io/wallet-connector": "1.8.1",
+        "@babylonlabs-io/wallet-connector": "1.8.2",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
         "@cosmjs/proto-signing": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/@babylonlabs-io/wallet-connector": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.8.1.tgz",
-      "integrity": "sha512-9xYy2Ba4p9YDfX73e7ETQy3nOAURczSxgLI4IeyOzphOtzjZHgv84VoeHVsR8bA811kpUlVhOiqOJSOW/D6IrA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.8.2.tgz",
+      "integrity": "sha512-OvT9Id8Au6CEf1HfCw6X3rUskvKvD+wSqbIZUhJcuxYBUZwk/kb3oweenBusuya9nfbBWQI7B0WhSHU4WfQiqg==",
       "dependencies": {
         "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
         "@cosmjs/stargate": "^0.32.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babylonlabs-io/babylon-proto-ts": "1.1.0",
     "@babylonlabs-io/btc-staking-ts": "2.3.4",
     "@babylonlabs-io/core-ui": "1.4.1",
-    "@babylonlabs-io/wallet-connector": "1.8.1",
+    "@babylonlabs-io/wallet-connector": "1.8.2",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",


### PR DESCRIPTION
Bumps `wallet-connector` to 1.8.2
Fixes OKX `.enable` and `.connect`