### PR TITLE
feat: add NEW_UI FF

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,6 +70,7 @@ jobs:
           NEXT_PUBLIC_FF_ENABLE_LEDGER: ${{ vars.NEXT_PUBLIC_FF_ENABLE_LEDGER }}
           NEXT_PUBLIC_FF_PHASE_3: ${{ vars.NEXT_PUBLIC_FF_PHASE_3 }}
           NEXT_PUBLIC_FF_BABYSTAKING: ${{ vars.NEXT_PUBLIC_FF_BABYSTAKING }}
+          NEXT_PUBLIC_FF_NEW_UI: ${{ vars.NEXT_PUBLIC_FF_NEW_UI }}
 
       - name: Generate sha256sum checksum
         run: |

--- a/src/ui/common/api/getFinalityProvidersV2.ts
+++ b/src/ui/common/api/getFinalityProvidersV2.ts
@@ -61,7 +61,7 @@ export const getFinalityProvidersV2 = async ({
     sort_by: sortBy,
     order,
     name,
-    bsn_id: bsnId,
+    ...(bsnId ? { bsn_id: bsnId } : {}),
   };
 
   const response = await apiWrapper<FinalityProvidersAPIResponse>(

--- a/src/ui/common/api/getNetworkInfo.ts
+++ b/src/ui/common/api/getNetworkInfo.ts
@@ -24,7 +24,6 @@ interface NetworkInfoAPI {
   params: {
     bbn: BbnParams[];
     btc: BtcCheckpointParams[];
-    max_bsn_fp_providers?: number;
   };
 }
 
@@ -42,7 +41,7 @@ export interface BbnParams {
   unbonding_time_blocks: number;
   unbonding_fee_sat: number;
   min_commission_rate: string;
-  max_active_finality_providers: number;
+  max_finality_providers: number;
   delegation_creation_base_gas_fee: number;
   btc_activation_height: number;
   allow_list_expiration_height: number;
@@ -73,7 +72,7 @@ export const getNetworkInfo = async (): Promise<NetworkInfo> => {
       unbondingTime: v.unbonding_time_blocks,
       unbondingFeeSat: v.unbonding_fee_sat,
       minCommissionRate: v.min_commission_rate,
-      maxActiveFinalityProviders: v.max_active_finality_providers,
+      maxFinalityProviders: v.max_finality_providers || 1, // default to 1 if not set
       delegationCreationBaseGasFee: v.delegation_creation_base_gas_fee,
       slashing: {
         slashingPkScriptHex: v.slashing_pk_script,
@@ -159,7 +158,6 @@ export const getNetworkInfo = async (): Promise<NetworkInfo> => {
         versions: epochCheckVersions,
         genesisParam: genesisEpochCheckParam,
       },
-      maxBsnFpProviders: params.max_bsn_fp_providers,
     },
   };
 };

--- a/src/ui/common/state/FinalityProviderState.tsx
+++ b/src/ui/common/state/FinalityProviderState.tsx
@@ -2,7 +2,6 @@ import { useDebounce } from "@uidotdev/usehooks";
 import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
 import { useSearchParams } from "react-router";
 
-import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
 import { useFinalityProviders } from "@/ui/common/hooks/client/api/useFinalityProviders";
 import { useFinalityProvidersV2 } from "@/ui/common/hooks/client/api/useFinalityProvidersV2";
 import {
@@ -37,8 +36,6 @@ interface FinalityProviderState {
   fetchNextPage: () => void;
   getFinalityProviderName: (btcPkHex: string) => string | undefined;
 }
-
-const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
 
 const FP_STATUSES = {
   [FinalityProviderStateEnum.ACTIVE]: 1,
@@ -109,7 +106,9 @@ export function FinalityProviderState({ children }: PropsWithChildren) {
       sortBy: sortState.field,
       order: sortState.direction,
       name: debouncedSearch,
-      bsnId: FeatureFlagService.IsPhase3Enabled ? "all" : BBN_CHAIN_ID,
+      // By default, if no bsn is passed, the FP endpoint will return babylon
+      // FP only
+      ...(FeatureFlagService.IsPhase3Enabled ? { bsnId: "all" } : {}),
     });
 
   const { data: dataV1 } = useFinalityProviders();

--- a/src/ui/common/state/MultistakingState.tsx
+++ b/src/ui/common/state/MultistakingState.tsx
@@ -38,6 +38,8 @@ interface FieldOptions {
   errors?: Record<string, { level: "warning" | "default" | "error" }>;
 }
 
+const DEFAULT_MAX_FINALITY_PROVIDERS = 1;
+
 export interface MultistakingState {
   stakingModalPage: StakingModalPage;
   setStakingModalPage: (page: StakingModalPage) => void;
@@ -50,7 +52,7 @@ const { StateProvider, useState: useMultistakingState } =
   createStateUtils<MultistakingState>({
     stakingModalPage: StakingModalPage.DEFAULT,
     setStakingModalPage: () => {},
-    maxFinalityProviders: 3,
+    maxFinalityProviders: DEFAULT_MAX_FINALITY_PROVIDERS, // Default to 1 FP in staking
     validationSchema: undefined,
     formFields: [],
   });
@@ -60,7 +62,9 @@ export function MultistakingState({ children }: PropsWithChildren) {
     StakingModalPage.DEFAULT,
   );
   const { data: networkInfo } = useNetworkInfo();
-  const maxFinalityProviders = networkInfo?.params.maxBsnFpProviders ?? 3;
+  const maxFinalityProviders =
+    networkInfo?.params.bbnStakingParams.latestParam.maxFinalityProviders ??
+    DEFAULT_MAX_FINALITY_PROVIDERS;
   const { stakableBtcBalance } = useBalanceState();
   const { stakingInfo } = useStakingState();
 

--- a/src/ui/common/types/networkInfo.ts
+++ b/src/ui/common/types/networkInfo.ts
@@ -3,7 +3,7 @@ import { StakingParams } from "@babylonlabs-io/btc-staking-ts";
 export interface BbnStakingParamsVersion extends StakingParams {
   version: number;
   minCommissionRate: string;
-  maxActiveFinalityProviders: number;
+  maxFinalityProviders: number;
   delegationCreationBaseGasFee: number;
   btcActivationHeight: number;
   allowListExpirationHeight: number;
@@ -36,7 +36,6 @@ export interface StakingStatus {
 export interface Params {
   bbnStakingParams: BbnStakingParams;
   btcEpochCheckParams: BtcEpochCheckParams;
-  maxBsnFpProviders?: number;
 }
 
 export interface NetworkInfo {

--- a/src/ui/common/utils/FeatureFlagService.ts
+++ b/src/ui/common/utils/FeatureFlagService.ts
@@ -45,4 +45,20 @@ export default {
   get IsBabyStakingEnabled() {
     return process.env.NEXT_PUBLIC_FF_BABYSTAKING === "true";
   },
+
+  /**
+   * New UI feature flag
+   *
+   * Purpose: Enables new UI which was designed as part of the phase-3 project,
+   * but this FF does not control the phase-3 functionality,
+   * which is the multi-staking, delegation-expansion etc. Instead, it only toggle
+   * between the old phase 2.5 UI to the new one.
+   * true: UI will show the new phase-3 liked UI, but still surve single FP staking
+   * false: Old phase 2.5 UI with single FP staking
+   * Why needed: To gradually roll out new UI.
+   * ETA for removal: 27th July 2025
+   */
+  get IsNewUIEnabled() {
+    return process.env.NEXT_PUBLIC_FF_NEW_UI === "true";
+  },
 };

--- a/src/ui/legacy/components/Multistaking/MultistakingForm/MultistakingForm.tsx
+++ b/src/ui/legacy/components/Multistaking/MultistakingForm/MultistakingForm.tsx
@@ -14,7 +14,6 @@ import {
   type MultistakingFormFields,
 } from "@/ui/legacy/state/MultistakingState";
 import { StakingStep, useStakingState } from "@/ui/legacy/state/StakingState";
-import FeatureFlagService from "@/ui/legacy/utils/FeatureFlagService";
 
 import { ConnectButton } from "./ConnectButton";
 import { FormAlert } from "./FormAlert";
@@ -31,7 +30,7 @@ export function MultistakingForm() {
     blocked: isGeoBlocked,
     errorMessage: geoBlockMessage,
   } = useStakingState();
-  const { validationSchema, maxFinalityProviders } = useMultistakingState();
+  const { validationSchema } = useMultistakingState();
 
   const handlePreview = useCallback(
     (formValues: MultistakingFormFields) => {
@@ -72,11 +71,8 @@ export function MultistakingForm() {
         <HiddenField name="feeAmount" defaultValue="0" />
         <div className="flex flex-col gap-6 lg:flex-row">
           <Card className="flex-1 min-w-0 flex flex-col gap-2">
-            <BsnFinalityProviderField
-              max={
-                FeatureFlagService.IsPhase3Enabled ? maxFinalityProviders : 1
-              }
-            />
+            {/* Legacy UI only support single FP staking */}
+            <BsnFinalityProviderField max={1} />
             <AmountSubsection />
             <FeesSection />
 

--- a/src/ui/legacy/state/FinalityProviderState.tsx
+++ b/src/ui/legacy/state/FinalityProviderState.tsx
@@ -2,7 +2,6 @@ import { useDebounce } from "@uidotdev/usehooks";
 import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
 import { useSearchParams } from "react-router";
 
-import { getNetworkConfigBBN } from "@/ui/legacy/config/network/bbn";
 import { useFinalityProviders } from "@/ui/legacy/hooks/client/api/useFinalityProviders";
 import { useFinalityProvidersV2 } from "@/ui/legacy/hooks/client/api/useFinalityProvidersV2";
 import {
@@ -11,7 +10,6 @@ import {
   type FinalityProvider,
 } from "@/ui/legacy/types/finalityProviders";
 import { createStateUtils } from "@/ui/legacy/utils/createStateUtils";
-import FeatureFlagService from "@/ui/legacy/utils/FeatureFlagService";
 
 interface SortState {
   field?: string;
@@ -37,8 +35,6 @@ interface FinalityProviderState {
   fetchNextPage: () => void;
   getFinalityProviderName: (btcPkHex: string) => string | undefined;
 }
-
-const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
 
 const FP_STATUSES = {
   [FinalityProviderStateEnum.ACTIVE]: 1,
@@ -109,7 +105,6 @@ export function FinalityProviderState({ children }: PropsWithChildren) {
       sortBy: sortState.field,
       order: sortState.direction,
       name: debouncedSearch,
-      bsnId: FeatureFlagService.IsPhase3Enabled ? "all" : BBN_CHAIN_ID,
     });
 
   const { data: dataV1 } = useFinalityProviders();

--- a/src/ui/legacy/state/MultistakingState.tsx
+++ b/src/ui/legacy/state/MultistakingState.tsx
@@ -11,7 +11,6 @@ import {
 
 import { validateDecimalPoints } from "@/ui/legacy/components/Staking/Form/validation/validation";
 import { getNetworkConfigBTC } from "@/ui/legacy/config/network/btc";
-import { useNetworkInfo } from "@/ui/legacy/hooks/client/api/useNetworkInfo";
 import { satoshiToBtc } from "@/ui/legacy/utils/btc";
 import { createStateUtils } from "@/ui/legacy/utils/createStateUtils";
 import {
@@ -50,7 +49,8 @@ const { StateProvider, useState: useMultistakingState } =
   createStateUtils<MultistakingState>({
     stakingModalPage: StakingModalPage.DEFAULT,
     setStakingModalPage: () => {},
-    maxFinalityProviders: 3,
+    // Legacy UI only support single FP staking
+    maxFinalityProviders: 1,
     validationSchema: undefined,
     formFields: [],
   });
@@ -59,8 +59,6 @@ export function MultistakingState({ children }: PropsWithChildren) {
   const [stakingModalPage, setStakingModalPage] = useState<StakingModalPage>(
     StakingModalPage.DEFAULT,
   );
-  const { data: networkInfo } = useNetworkInfo();
-  const maxFinalityProviders = networkInfo?.params.maxBsnFpProviders ?? 3;
   const { stakableBtcBalance } = useBalanceState();
   const { stakingInfo } = useStakingState();
 
@@ -74,10 +72,7 @@ export function MultistakingState({ children }: PropsWithChildren) {
             .transform((value) => Object.values(value))
             .required("Add Finality Provider")
             .min(1, "Add Finality Provider")
-            .max(
-              maxFinalityProviders,
-              `Maximum ${maxFinalityProviders} finality providers allowed.`,
-            ),
+            .max(1, `Maximum of 1 finality provider allowed.`),
         },
         {
           field: "term",
@@ -154,7 +149,7 @@ export function MultistakingState({ children }: PropsWithChildren) {
             .moreThan(0, "Staking fee amount must be greater than 0."),
         },
       ] as const,
-    [stakingInfo, stakableBtcBalance, maxFinalityProviders],
+    [stakingInfo, stakableBtcBalance],
   );
 
   const validationSchema = useMemo(() => {
@@ -172,17 +167,11 @@ export function MultistakingState({ children }: PropsWithChildren) {
     () => ({
       stakingModalPage,
       setStakingModalPage,
-      maxFinalityProviders,
+      maxFinalityProviders: 1, // Legacy UI only support single FP staking
       validationSchema,
       formFields,
     }),
-    [
-      stakingModalPage,
-      setStakingModalPage,
-      maxFinalityProviders,
-      validationSchema,
-      formFields,
-    ],
+    [stakingModalPage, setStakingModalPage, validationSchema, formFields],
   );
 
   return <StateProvider value={context}>{children}</StateProvider>;

--- a/src/ui/router.tsx
+++ b/src/ui/router.tsx
@@ -9,7 +9,7 @@ import LegacyPage from "./legacy/page";
 
 export const Router = () => (
   <Routes>
-    {FF.IsPhase3Enabled ? (
+    {FF.IsNewUIEnabled ? (
       <Route path="/" element={<Layout />}>
         <Route path="btc" element={<BTCStaking />} />
         <Route index element={<Navigate to="btc" replace />} />


### PR DESCRIPTION
1. Add NEW_UI Feature flag to toggle between phase 2.5 UI and the new Phase 3 UI but only does the single FP staking
2. Correct the use of PHASE_3 Feature flag to only be used on controlling the num of Finality providers in the staking

Note: the current PHASE_3 for multi-staking is broken but that was due to backend bug.