### PR TITLE
fix: bump core-ui to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "1.1.0",
         "@babylonlabs-io/btc-staking-ts": "2.3.4",
-        "@babylonlabs-io/core-ui": "1.4.2",
-        "@babylonlabs-io/wallet-connector": "1.8.3",
+        "@babylonlabs-io/core-ui": "1.6.0",
+        "@babylonlabs-io/wallet-connector": "1.8.4",
         "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
         "@cosmjs/proto-signing": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
@@ -2217,9 +2217,9 @@
       }
     },
     "node_modules/@babylonlabs-io/core-ui": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/core-ui/-/core-ui-1.4.2.tgz",
-      "integrity": "sha512-N0YVN8rR1Sp2AxjkxMgOtORb05pPY3KDCiD5hKXbyAP5lb71kJJGR+Sr2EeGdkBbkby3nQq7EIgYDZkUbn2ukg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/core-ui/-/core-ui-1.6.0.tgz",
+      "integrity": "sha512-/HhmbjIHp4/4PYyMiBqnmeY6AcWVK28B6uGxOydYMjvqQFiGLV9kIOWosp5iUTNt4YFqxXUcSYY3Wbv6OQfUWw==",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@popperjs/core": "^2.11.8",
@@ -2236,9 +2236,9 @@
       }
     },
     "node_modules/@babylonlabs-io/wallet-connector": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.8.3.tgz",
-      "integrity": "sha512-lWweRf35kCn6LhQswGI0tobVBDMfdz6oaSsSEDbJmyTTUEF9RRtSM1SEXSp9DfNjv79CIs6sHOhYPbpYp0c2/A==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/wallet-connector/-/wallet-connector-1.8.4.tgz",
+      "integrity": "sha512-oSyAHePwdWGTfDlEP3awVC8OFOWXKZPWMIptypgHsdW94B9frDXCr7GwS/9k+TqtR1KSeM7qUkHSxzjE3B4MMQ==",
       "dependencies": {
         "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
         "@cosmjs/stargate": "^0.32.4",
@@ -2258,7 +2258,7 @@
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
-        "@babylonlabs-io/core-ui": "1.4.2",
+        "@babylonlabs-io/core-ui": "1.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.5.4"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "dependencies": {
     "@babylonlabs-io/babylon-proto-ts": "1.1.0",
     "@babylonlabs-io/btc-staking-ts": "2.3.4",
-    "@babylonlabs-io/core-ui": "1.4.2",
-    "@babylonlabs-io/wallet-connector": "1.8.3",
+    "@babylonlabs-io/core-ui": "1.6.0",
+    "@babylonlabs-io/wallet-connector": "1.8.4",
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",

--- a/src/ui/common/components/Multistaking/MultistakingForm/FinalityProvidersSection.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/FinalityProvidersSection.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/ui/common/state/FinalityProviderBsnState";
 import { useFinalityProviderState } from "@/ui/common/state/FinalityProviderState";
 import { useMultistakingState } from "@/ui/common/state/MultistakingState";
-import FeatureFlagService from "@/ui/common/utils/FeatureFlagService";
 
 type SelectedProviderItemLocal = {
   bsnId: string;
@@ -96,11 +95,16 @@ export function FinalityProvidersSection() {
     }
   };
 
+  const actionText = allowsMultipleBsns
+    ? "Add BSN and Finality Provider"
+    : "Add Finality Provider";
+
   return (
     <Fragment>
       <FinalityProviderSubsection
-        max={FeatureFlagService.IsPhase3Enabled ? maxFinalityProviders : 1}
+        max={maxFinalityProviders}
         items={selectedItems}
+        actionText={actionText}
         onAdd={handleOpen}
         onRemove={handleRemove}
       />

--- a/src/ui/common/state/MultistakingState.tsx
+++ b/src/ui/common/state/MultistakingState.tsx
@@ -19,6 +19,8 @@ import {
   formatStakingAmount,
 } from "@/ui/common/utils/formTransforms";
 
+import FeatureFlagService from "../utils/FeatureFlagService";
+
 import { useBalanceState } from "./BalanceState";
 import { StakingModalPage, useStakingState } from "./StakingState";
 
@@ -62,9 +64,15 @@ export function MultistakingState({ children }: PropsWithChildren) {
     StakingModalPage.DEFAULT,
   );
   const { data: networkInfo } = useNetworkInfo();
+  // The maxFinalityProviders is controlled by the FF. Only when IsPhase3Enabled
+  // is true, the maxFinalityProviders is the max number of FP that can be
+  // selected. Otherwise, it is 1.
   const maxFinalityProviders =
-    networkInfo?.params.bbnStakingParams.latestParam.maxFinalityProviders ??
-    DEFAULT_MAX_FINALITY_PROVIDERS;
+    FeatureFlagService.IsPhase3Enabled &&
+    networkInfo?.params.bbnStakingParams.latestParam.maxFinalityProviders
+      ? networkInfo.params.bbnStakingParams.latestParam.maxFinalityProviders
+      : DEFAULT_MAX_FINALITY_PROVIDERS;
+
   const { stakableBtcBalance } = useBalanceState();
   const { stakingInfo } = useStakingState();
 


### PR DESCRIPTION
1. Bump core-ui version to adopt the latest component which expect simple-staking to pass the action text.
2. update the feature flag so that the mutlistaking state's maxFinalityProvider is controlled by the PHASE_3 FF. hence all the subsequent components no longer need to be aware of FF. it can rely on the maxFinalityProvider property instead.