### PR TITLE
fix: stable reference on staking fees section

### DIFF
--- a/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
@@ -24,6 +24,16 @@ export function StakingFeesSection() {
   const term = useWatch({ name: "term" });
   const finalityProviders = useWatch({ name: "finalityProviders" });
 
+  // Stable representation of the selected provider map so that the effect
+  // only re-runs when the actual content changes, not every render.
+  const providerIds = useMemo(
+    () =>
+      Object.values(finalityProviders ?? {})
+        .sort()
+        .join(","),
+    [finalityProviders],
+  );
+
   const { calculateFeeAmount } = useStakingService();
   const { stakingInfo } = useStakingState();
 
@@ -42,9 +52,7 @@ export function StakingFeesSection() {
 
     const run = () => {
       try {
-        const validProviders = Object.values(
-          finalityProviders ?? {},
-        ) as string[];
+        const validProviders = providerIds ? providerIds.split(",") : [];
 
         if (!validProviders.length || !amount || !term || !feeRate) {
           if (!cancelled) {
@@ -93,7 +101,7 @@ export function StakingFeesSection() {
     feeRate,
     amount,
     term,
-    finalityProviders,
+    providerIds,
     setValue,
     setError,
     clearErrors,

--- a/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
@@ -24,8 +24,6 @@ export function StakingFeesSection() {
   const term = useWatch({ name: "term" });
   const finalityProviders = useWatch({ name: "finalityProviders" });
 
-  // Stable representation of the selected provider map so that the effect
-  // only re-runs when the actual content changes, not every render.
   const providerIds = useMemo(
     () =>
       Object.values(finalityProviders ?? {})

--- a/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
@@ -24,11 +24,8 @@ export function StakingFeesSection() {
   const term = useWatch({ name: "term" });
   const finalityProviders = useWatch({ name: "finalityProviders" });
 
-  const providerIds = useMemo(
-    () =>
-      Object.values(finalityProviders ?? {})
-        .sort()
-        .join(","),
+  const providerIdsJson = useMemo(
+    () => JSON.stringify(Object.values(finalityProviders ?? {}).sort()),
     [finalityProviders],
   );
 
@@ -50,7 +47,9 @@ export function StakingFeesSection() {
 
     const run = () => {
       try {
-        const validProviders = providerIds ? providerIds.split(",") : [];
+        const validProviders = providerIdsJson
+          ? (JSON.parse(providerIdsJson) as string[])
+          : [];
 
         if (!validProviders.length || !amount || !term || !feeRate) {
           if (!cancelled) {
@@ -99,7 +98,7 @@ export function StakingFeesSection() {
     feeRate,
     amount,
     term,
-    providerIds,
+    providerIdsJson,
     setValue,
     setError,
     clearErrors,


### PR DESCRIPTION
This fixes an endless loop that caused rerenders and a crash on the UI

The finality provider object was unstable, which caused the useEffect to be rerun endlessly. We now serialise and useMemo to make the finality provider object stable.