### PR TITLE
feat: implements TableElement from core-ui

### DIFF
--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
@@ -98,9 +98,6 @@ export const FinalityProviderTable = ({ selectedFP, onSelectRow }: Props) => {
             }}
             attributes={{
               Status: status,
-              [`${coinSymbol} PK`]: fp.btcPk
-                ? `${fp.btcPk.slice(0, 5)}...${fp.btcPk.slice(-5)}`
-                : "",
               "Total Delegation": (
                 <>
                   {totalDelegation} {coinSymbol}


### PR DESCRIPTION
Removes the implementation for TableElement from simple-staking, uses core-ui's instead.
This brings over the improvements made on core-ui TableElement

<img width="725" height="462" alt="Screenshot 2025-07-24 at 02 15 22" src="https://github.com/user-attachments/assets/92908de0-d9cd-4fd8-a652-f940d165906f" />
