### PR TITLE
feat: expansion API response updates

### DIFF
--- a/src/ui/common/api/getDelegationsV2.ts
+++ b/src/ui/common/api/getDelegationsV2.ts
@@ -35,6 +35,7 @@ interface DelegationV2API {
     covenant_unbonding_signatures?: {
       covenant_btc_pk_hex: string;
       signature_hex: string;
+      stake_expansion_signature_hex?: string;
     }[];
     slashing: {
       unbonding_slashing_tx_hex: string;
@@ -42,6 +43,8 @@ interface DelegationV2API {
     };
   };
   state: string;
+  can_expand?: boolean;
+  previous_staking_tx_hash_hex?: string;
 }
 
 export const getDelegationV2 = async (
@@ -115,6 +118,8 @@ const apiToDelegationV2 = (apiDelegation: DelegationV2API): DelegationV2 => {
     state,
     unbondingTimelock: apiDelegation.delegation_unbonding.unbonding_timelock,
     unbondingTxHex: apiDelegation.delegation_unbonding.unbonding_tx,
+    canExpand: apiDelegation.can_expand,
+    previousStakingTxHashHex: apiDelegation.previous_staking_tx_hash_hex,
     slashing: {
       stakingSlashingTxHex:
         apiDelegation.delegation_staking.slashing.slashing_tx_hex,
@@ -128,6 +133,7 @@ const apiToDelegationV2 = (apiDelegation: DelegationV2API): DelegationV2 => {
         (signature) => ({
           covenantBtcPkHex: signature.covenant_btc_pk_hex,
           signatureHex: signature.signature_hex,
+          stakeExpansionSignatureHex: signature.stake_expansion_signature_hex,
         }),
       ),
   };

--- a/src/ui/common/types/delegationsV2.ts
+++ b/src/ui/common/types/delegationsV2.ts
@@ -21,9 +21,12 @@ export interface DelegationV2 extends DelegationLike {
   endHeight: number;
   unbondingTimelock: number;
   unbondingTxHex: string;
+  canExpand?: boolean;
+  previousStakingTxHashHex?: string;
   covenantUnbondingSignatures?: {
     covenantBtcPkHex: string;
     signatureHex: string;
+    stakeExpansionSignatureHex?: string;
   }[];
   slashing: {
     stakingSlashingTxHex: string;


### PR DESCRIPTION
Updates the API response for the expansion related stuff
- `can_expand`
- covenant signatures - `stake_expansion_signature_hex`
- `previous_staking_tx_hash_hex` to check out the history