### PR TITLE
fixes imports for core-ui

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,7 +6,6 @@
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -14,7 +13,6 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -23,7 +21,7 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": "./",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*", "./node_modules/@babylonlabs-io/core-ui/dist/*"]
     }
   },
   "include": ["src", "tests", "sentry.client.config.ts"]


### PR DESCRIPTION
## Fix TSX type error for `HiddenField` props

Building the app threw the following error:

```
Type '{ name: string; defaultValue: string | undefined; }' is not assignable to type 'IntrinsicAttributes & HiddenFieldProps'.
  Property 'name' does not exist on type 'IntrinsicAttributes & HiddenFieldProps'.
```

`HiddenFieldProps` is defined in `@babylonlabs-io/core-ui` and extends `FieldProps`, imported as:

```ts
import { FieldProps } from "@/widgets/form/types";
```

Our `tsconfig.app.json` mapped the alias `@/*` exclusively to `./src/*`, so TypeScript tried to resolve `@/widgets/form/types` inside our own source tree, didn’t find the file, and silently treated the unresolved import as `any`.  
As a result, the `name` property was missing from the library’s `HiddenFieldProps`, causing the JSX type-checking failure.

### Fix
Extend the existing alias so it also points to the library’s compiled output:

```jsonc
// tsconfig.app.json
"paths": {
  "@/*": [
    "./src/*",
    "./node_modules/@babylonlabs-io/core-ui/dist/*" // new
  ]
}
```

Both our code and the library now resolve `@/…` correctly, restoring the full `HiddenFieldProps` definition and eliminating the error.