### PR TITLE
feat: expansion history

### DIFF
--- a/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
+++ b/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
@@ -4,10 +4,14 @@ import {
   AccordionSummary,
   Text,
 } from "@babylonlabs-io/core-ui";
+import { useState } from "react";
 import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
 
 import iconBSNFp from "@/ui/common/assets/expansion-bsn-fp.svg";
 import iconHistory from "@/ui/common/assets/expansion-history.svg";
+import { ExpansionHistoryModal } from "@/ui/common/components/ExpansionHistory/ExpansionHistoryModal";
+import { useExpansionHistoryService } from "@/ui/common/hooks/services/useExpansionHistoryService";
+import { useDelegationV2State } from "@/ui/common/state/DelegationV2State";
 import { useStakingExpansionState } from "@/ui/common/state/StakingExpansionState";
 import { StakingExpansionStep } from "@/ui/common/state/StakingExpansionTypes";
 import { DelegationWithFP } from "@/ui/common/types/delegationsV2";
@@ -23,6 +27,10 @@ export function StakeExpansionSection({
 }: StakeExpansionSectionProps) {
   const { goToStep, setFormData, processing, maxFinalityProviders, canExpand } =
     useStakingExpansionState();
+  const { delegations } = useDelegationV2State();
+  const { getHistoryCount } = useExpansionHistoryService();
+  const [expansionHistoryModalOpen, setExpansionHistoryModalOpen] =
+    useState(false);
 
   const currentBsnCount = delegation.finalityProviderBtcPksHex.length;
   const canExpandDelegation = canExpand(delegation);
@@ -55,13 +63,16 @@ export function StakeExpansionSection({
    * Handle expansion history button click.
    */
   const handleExpansionHistory = () => {
-    console.log(
-      `expansion history clicked, staking tx: ${delegation.stakingTxHashHex}`,
-    );
+    if (expansionHistoryCount > 0) {
+      setExpansionHistoryModalOpen(true);
+    }
   };
 
-  // Count expansion history, 0 is regular staking, 1+ is expanded
-  const expansionHistoryCount = delegation.previousStakingTxHashHex ? "1+" : 0;
+  // Calculate actual expansion history count
+  const expansionHistoryCount = getHistoryCount(
+    delegations,
+    delegation.stakingTxHashHex,
+  );
 
   return (
     <div className="w-full">
@@ -95,11 +106,18 @@ export function StakeExpansionSection({
               text="Expansion History"
               counter={`${expansionHistoryCount}`}
               onClick={handleExpansionHistory}
-              disabled={processing}
+              disabled={expansionHistoryCount === 0 || processing}
             />
           </div>
         </AccordionDetails>
       </Accordion>
+
+      <ExpansionHistoryModal
+        open={expansionHistoryModalOpen}
+        onClose={() => setExpansionHistoryModalOpen(false)}
+        targetDelegation={delegation}
+        allDelegations={delegations}
+      />
     </div>
   );
 }

--- a/src/ui/common/components/ExpansionHistory/ExpansionHistoryModal.tsx
+++ b/src/ui/common/components/ExpansionHistory/ExpansionHistoryModal.tsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+  Text,
+} from "@babylonlabs-io/core-ui";
+
+import { ResponsiveDialog } from "@/ui/common/components/Modals/ResponsiveDialog";
+import { useExpansionHistoryModalData } from "@/ui/common/hooks/useExpansionHistoryModalData";
+import {
+  DelegationV2,
+  DelegationWithFP,
+} from "@/ui/common/types/delegationsV2";
+
+import { ActivityCard } from "../ActivityCard/ActivityCard";
+
+interface ExpansionHistoryModalProps {
+  open: boolean;
+  onClose: () => void;
+  targetDelegation: DelegationWithFP | null;
+  allDelegations: DelegationV2[];
+}
+
+export function ExpansionHistoryModal({
+  open,
+  onClose,
+  targetDelegation,
+  allDelegations,
+}: ExpansionHistoryModalProps) {
+  const { expansionChain, activityCards, hasExpansionHistory } =
+    useExpansionHistoryModalData({
+      targetDelegation,
+      allDelegations,
+    });
+
+  if (!targetDelegation) return null;
+
+  return (
+    <ResponsiveDialog open={open} onClose={onClose}>
+      <DialogHeader
+        title="Expansion History"
+        onClose={onClose}
+        className="text-accent-primary"
+      />
+      <DialogBody className="flex flex-col pb-4 pt-4 text-accent-primary gap-4 max-h-[70vh] overflow-y-auto">
+        <div className="flex flex-col gap-2">
+          {!hasExpansionHistory ? (
+            <div className="text-center py-8">
+              <Text variant="body1" className="text-accent-secondary">
+                No expansion history found
+              </Text>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {activityCards.map((cardData, index) => (
+                <ActivityCard
+                  key={expansionChain[index]?.stakingTxHashHex || index}
+                  data={cardData}
+                  className="border border-secondary-strokeLight"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogBody>
+      <DialogFooter className="flex gap-4">
+        <Button
+          variant="contained"
+          className="flex-1 text-xs sm:text-base"
+          onClick={onClose}
+        >
+          Close
+        </Button>
+      </DialogFooter>
+    </ResponsiveDialog>
+  );
+}

--- a/src/ui/common/hooks/services/useExpansionHistoryService.ts
+++ b/src/ui/common/hooks/services/useExpansionHistoryService.ts
@@ -1,0 +1,88 @@
+import { useCallback, useMemo } from "react";
+
+import { DelegationV2 } from "@/ui/common/types/delegationsV2";
+
+export interface ExpansionHistoryData {
+  historyCount: number;
+  expansionChain: DelegationV2[];
+}
+
+export interface ExpansionHistoryCache {
+  [txHashHex: string]: ExpansionHistoryData;
+}
+
+export function useExpansionHistoryService() {
+  const cache = useMemo<ExpansionHistoryCache>(() => ({}), []);
+
+  const buildExpansionChain = useCallback(
+    (delegations: DelegationV2[], targetTxHash: string): DelegationV2[] => {
+      const delegationMap = new Map<string, DelegationV2>();
+      delegations.forEach((delegation) => {
+        delegationMap.set(delegation.stakingTxHashHex, delegation);
+      });
+
+      const chain: DelegationV2[] = [];
+      let currentTxHash = targetTxHash;
+
+      while (currentTxHash) {
+        const delegation = delegationMap.get(currentTxHash);
+        if (!delegation) break;
+
+        chain.unshift(delegation);
+        currentTxHash = delegation.previousStakingTxHashHex || "";
+      }
+
+      return chain;
+    },
+    [],
+  );
+
+  const calculateExpansionHistory = useCallback(
+    (
+      delegations: DelegationV2[],
+      targetTxHash: string,
+    ): ExpansionHistoryData => {
+      if (cache[targetTxHash]) {
+        return cache[targetTxHash];
+      }
+
+      const expansionChain = buildExpansionChain(delegations, targetTxHash);
+      const historyCount = Math.max(0, expansionChain.length - 1);
+
+      const result: ExpansionHistoryData = {
+        historyCount,
+        expansionChain,
+      };
+
+      cache[targetTxHash] = result;
+      return result;
+    },
+    [buildExpansionChain, cache],
+  );
+
+  const getExpansionChain = useCallback(
+    (delegations: DelegationV2[], targetTxHash: string): DelegationV2[] => {
+      return calculateExpansionHistory(delegations, targetTxHash)
+        .expansionChain;
+    },
+    [calculateExpansionHistory],
+  );
+
+  const getHistoryCount = useCallback(
+    (delegations: DelegationV2[], targetTxHash: string): number => {
+      return calculateExpansionHistory(delegations, targetTxHash).historyCount;
+    },
+    [calculateExpansionHistory],
+  );
+
+  const clearCache = useCallback(() => {
+    Object.keys(cache).forEach((key) => delete cache[key]);
+  }, [cache]);
+
+  return {
+    calculateExpansionHistory,
+    getExpansionChain,
+    getHistoryCount,
+    clearCache,
+  };
+}

--- a/src/ui/common/hooks/useExpansionHistoryModalData.ts
+++ b/src/ui/common/hooks/useExpansionHistoryModalData.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+
+import { useExpansionHistoryService } from "@/ui/common/hooks/services/useExpansionHistoryService";
+import { useFinalityProviderState } from "@/ui/common/state/FinalityProviderState";
+import {
+  DelegationV2,
+  DelegationWithFP,
+} from "@/ui/common/types/delegationsV2";
+import { transformDelegationToActivityCard } from "@/ui/common/utils/delegationTransformers";
+
+import { ActivityCardData } from "../components/ActivityCard/ActivityCard";
+
+export interface UseExpansionHistoryModalDataProps {
+  targetDelegation: DelegationWithFP | null;
+  allDelegations: DelegationV2[];
+}
+
+export interface UseExpansionHistoryModalDataReturn {
+  expansionChain: DelegationV2[];
+  activityCards: ActivityCardData[];
+  hasExpansionHistory: boolean;
+}
+
+export function useExpansionHistoryModalData({
+  targetDelegation,
+  allDelegations,
+}: UseExpansionHistoryModalDataProps): UseExpansionHistoryModalDataReturn {
+  const { getExpansionChain } = useExpansionHistoryService();
+  const { finalityProviderMap } = useFinalityProviderState();
+
+  const expansionChain = useMemo(() => {
+    if (!targetDelegation || !allDelegations) return [];
+    return getExpansionChain(allDelegations, targetDelegation.stakingTxHashHex);
+  }, [targetDelegation, allDelegations, getExpansionChain]);
+
+  const activityCards = useMemo(() => {
+    return expansionChain.map((delegation, index) => {
+      const finalityProvider = finalityProviderMap.get(
+        delegation.finalityProviderBtcPksHex[0],
+      );
+      return transformDelegationToActivityCard(
+        delegation,
+        finalityProvider,
+        index,
+      );
+    });
+  }, [expansionChain, finalityProviderMap]);
+
+  const hasExpansionHistory = expansionChain.length > 0;
+
+  return {
+    expansionChain,
+    activityCards,
+    hasExpansionHistory,
+  };
+}

--- a/src/ui/common/utils/delegationTransformers.tsx
+++ b/src/ui/common/utils/delegationTransformers.tsx
@@ -1,0 +1,119 @@
+import bitcoin from "@/ui/common/assets/bitcoin.png";
+import { Status } from "@/ui/common/components/Delegations/DelegationList/components/Status";
+import { Hash } from "@/ui/common/components/Hash/Hash";
+import { FinalityProviderLogo } from "@/ui/common/components/Staking/FinalityProviders/FinalityProviderLogo";
+import { getNetworkConfigBTC } from "@/ui/common/config/network/btc";
+import { chainLogos } from "@/ui/common/constants";
+import {
+  DelegationV2,
+  DelegationWithFP,
+} from "@/ui/common/types/delegationsV2";
+import { FinalityProvider } from "@/ui/common/types/finalityProviders";
+import { satoshiToBtc } from "@/ui/common/utils/btc";
+import { maxDecimals } from "@/ui/common/utils/maxDecimals";
+import { durationTillNow } from "@/ui/common/utils/time";
+
+import {
+  ActivityCardData,
+  ActivityCardDetailItem,
+  ActivityListItemData,
+} from "../components/ActivityCard/ActivityCard";
+
+const { coinName } = getNetworkConfigBTC();
+
+// This should be further extended to include more details as needed
+export const transformDelegationToActivityCard = (
+  delegation: DelegationV2,
+  finalityProvider: FinalityProvider | undefined,
+  index: number,
+): ActivityCardData => {
+  // Create a delegation with FP for the Status component
+  const delegationWithFP: DelegationWithFP = {
+    ...delegation,
+    fp: finalityProvider as FinalityProvider,
+  };
+
+  const details: ActivityCardDetailItem[] = [
+    {
+      label: "Status",
+      value: finalityProvider ? (
+        <Status delegation={delegationWithFP} showTooltip={false} />
+      ) : (
+        "Unknown"
+      ),
+    },
+    {
+      label: "Inception",
+      value: delegation.bbnInceptionTime
+        ? durationTillNow(delegation.bbnInceptionTime, Date.now())
+        : "N/A",
+    },
+    {
+      label: "Tx Hash",
+      value: (
+        <Hash
+          value={delegation.stakingTxHashHex}
+          address
+          small
+          noFade
+          size="caption"
+        />
+      ),
+    },
+  ];
+
+  const listItems: {
+    label: string;
+    items: ActivityListItemData[];
+  }[] = [];
+
+  if (finalityProvider?.bsnId) {
+    const bsnLogo =
+      chainLogos[finalityProvider.bsnId] || chainLogos.placeholder;
+    listItems.push({
+      label: "BSN",
+      items: [
+        {
+          icon: bsnLogo,
+          iconAlt: finalityProvider.bsnId,
+          name: finalityProvider.bsnId,
+          id: finalityProvider.bsnId,
+        },
+      ],
+    });
+  }
+
+  if (finalityProvider) {
+    listItems.push({
+      label: "Finality Provider",
+      items: [
+        {
+          icon: (
+            <FinalityProviderLogo
+              logoUrl={finalityProvider.logo_url}
+              rank={finalityProvider.rank}
+              moniker={finalityProvider.description?.moniker}
+              className="w-4 h-4"
+            />
+          ),
+          iconAlt: finalityProvider.description?.moniker || "Finality Provider",
+          name:
+            finalityProvider.description?.moniker ||
+            `Provider ${finalityProvider.rank}`,
+          id: finalityProvider.btcPk,
+        },
+      ],
+    });
+  }
+
+  const stepLabel = index === 0 ? "Original Stake" : `Expansion ${index}`;
+  const formattedAmount = `${maxDecimals(satoshiToBtc(delegation.stakingAmount), 8)} ${coinName}`;
+
+  return {
+    formattedAmount: `${stepLabel} - ${formattedAmount}`,
+    icon: bitcoin,
+    iconAlt: "bitcoin",
+    details,
+    listItems: listItems.length > 0 ? listItems : undefined,
+  };
+};


### PR DESCRIPTION
Adds an MVP history of staking expansion
- count
- modal
- linked caching for the expansions and og staking transactions

Closes #1329 