### PR TITLE
feat: expansion modals

### DIFF
--- a/src/ui/common/components/Activity/components/ActivityList.tsx
+++ b/src/ui/common/components/Activity/components/ActivityList.tsx
@@ -33,6 +33,7 @@ import {
   ActivityListItemData,
 } from "../../ActivityCard/ActivityCard";
 import { DelegationModal } from "../../Delegations/DelegationList/components/DelegationModal";
+import { StakingExpansionModalSystem } from "../../StakingExpansion/StakingExpansionModalSystem";
 
 const networkConfig = getNetworkConfig();
 const { coinName } = getNetworkConfigBTC();
@@ -338,6 +339,8 @@ export function ActivityList() {
         onClose={closeConfirmationModal}
         networkConfig={networkConfig}
       />
+
+      <StakingExpansionModalSystem />
     </>
   );
 }

--- a/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
+++ b/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
@@ -64,7 +64,7 @@ export const StakingExpansionModal = ({
   const { calculateExpansionFeeAmount, displayExpansionPreview } =
     useStakingExpansionService();
   const { networkInfo } = useAppState();
-  const logger = useLogger("StakingExpansionModal");
+  const logger = useLogger();
 
   // Calculate the default staking timelock using the same logic as regular staking
   const defaultStakingTimeBlocks = useMemo(() => {
@@ -123,7 +123,9 @@ export const StakingExpansionModal = ({
 
       return pairs;
     } catch (error) {
-      logger.error("Failed to map existing BSN+FP pairs", { error });
+      logger.error(new Error("Failed to map existing BSN+FP pairs"), {
+        data: { error: String(error) },
+      });
       return {};
     }
   }, [
@@ -228,7 +230,9 @@ export const StakingExpansionModal = ({
       handleClose();
       displayExpansionPreview(finalFormData);
     } catch (error) {
-      logger.error("Failed to calculate expansion fee", { error });
+      logger.error(new Error("Failed to calculate expansion fee"), {
+        data: { error: String(error) },
+      });
     } finally {
       setIsCalculatingFee(false);
     }

--- a/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
+++ b/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
@@ -1,0 +1,283 @@
+/*
+ * Staking Expansion Modal - Integrated with existing BSN/FP modals
+ *
+ * This modal reuses the existing ChainSelectionModal and FinalityProviderModal
+ * from the regular staking flow, with adaptations for expansion:
+ * - No Babylon Genesis priority requirement (already exists in delegation)
+ * - "Expand" button instead of "Done" when BSN+FP pairs are selected
+ * - Allows adding multiple BSN+FP pairs before expanding
+ */
+
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+
+import { ChainSelectionModal } from "@/ui/common/components/Multistaking/ChainSelectionModal/ChainSelectionModal";
+import { FinalityProviderModal } from "@/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal";
+import { IS_FIXED_TERM_FIELD } from "@/ui/common/config";
+import { useNetworkFees } from "@/ui/common/hooks/client/api/useNetworkFees";
+import { useStakingExpansionService } from "@/ui/common/hooks/services/useStakingExpansionService";
+import { useLogger } from "@/ui/common/hooks/useLogger";
+import { useAppState } from "@/ui/common/state";
+import {
+  StakingModalPage,
+  useFinalityProviderBsnState,
+} from "@/ui/common/state/FinalityProviderBsnState";
+import { useFinalityProviderState } from "@/ui/common/state/FinalityProviderState";
+import { useStakingExpansionState } from "@/ui/common/state/StakingExpansionState";
+import { type StakingExpansionFormData } from "@/ui/common/state/StakingExpansionTypes";
+import { getFeeRateFromMempool } from "@/ui/common/utils/getFeeRateFromMempool";
+
+interface StakingExpansionModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Staking Expansion Modal - Integrated Implementation
+ *
+ * This modal integrates with existing ChainSelectionModal and FinalityProviderModal
+ * to provide BSN+FP selection for staking expansion.
+ *
+ * KEY DIFFERENCES FROM REGULAR STAKING:
+ * - No Babylon Genesis priority requirement (already exists)
+ * - "Expand" button shows when at least one BSN+FP pair is selected
+ * - Allows continuous adding of BSN+FP pairs before expanding
+ */
+export const StakingExpansionModal = ({
+  open,
+  onClose,
+}: StakingExpansionModalProps) => {
+  const { formData, setFormData, reset, getAvailableBsnSlots } =
+    useStakingExpansionState();
+
+  const {
+    stakingModalPage,
+    setStakingModalPage,
+    bsnList,
+    bsnLoading,
+    selectedBsnId,
+    setSelectedBsnId,
+  } = useFinalityProviderBsnState();
+
+  const { getRegisteredFinalityProvider } = useFinalityProviderState();
+  const { data: networkFees } = useNetworkFees();
+  const { defaultFeeRate } = getFeeRateFromMempool(networkFees);
+  const { calculateExpansionFeeAmount, displayExpansionPreview } =
+    useStakingExpansionService();
+  const { networkInfo } = useAppState();
+  const logger = useLogger("StakingExpansionModal");
+
+  // Calculate the default staking timelock using the same logic as regular staking
+  const defaultStakingTimeBlocks = useMemo(() => {
+    const latestParam = networkInfo?.params.bbnStakingParams?.latestParam;
+    if (!latestParam) {
+      // Return undefined if network info not available, will be set later when available
+      return undefined;
+    }
+
+    const { minStakingTimeBlocks = 0, maxStakingTimeBlocks = 0 } = latestParam;
+
+    // Use the exact same logic as regular staking (StakingState.tsx:210-213)
+    return IS_FIXED_TERM_FIELD || minStakingTimeBlocks === maxStakingTimeBlocks
+      ? maxStakingTimeBlocks
+      : undefined; // For variable term, don't set a default - let user choose
+  }, [networkInfo]);
+
+  // Local state for tracking selected BSN+FP pairs
+  const [selectedBsnFps, setSelectedBsnFps] = useState<Record<string, string>>(
+    {},
+  );
+  const [isCalculatingFee, setIsCalculatingFee] = useState(false);
+
+  // Get existing BSN+FP pairs from the original delegation with safety checks
+  const existingBsnFps = useMemo(() => {
+    try {
+      // Safety checks for data availability
+      if (!formData?.originalDelegation?.finalityProviderBtcPksHex) {
+        return {};
+      }
+
+      // Ensure it's an array
+      const fpPkHexArray = Array.isArray(
+        formData.originalDelegation.finalityProviderBtcPksHex,
+      )
+        ? formData.originalDelegation.finalityProviderBtcPksHex
+        : [];
+
+      if (fpPkHexArray.length === 0) {
+        return {};
+      }
+
+      const pairs: Record<string, string> = {};
+
+      fpPkHexArray.forEach((fpPkHex) => {
+        if (!fpPkHex || typeof fpPkHex !== "string") {
+          return;
+        }
+
+        const fp = getRegisteredFinalityProvider(fpPkHex);
+        if (fp && fp.bsnId) {
+          pairs[fp.bsnId] = fpPkHex;
+        }
+        // Note: If FP is not found or has no bsnId, we skip it (no action needed)
+      });
+
+      return pairs;
+    } catch (error) {
+      logger.error("Failed to map existing BSN+FP pairs", { error });
+      return {};
+    }
+  }, [
+    formData?.originalDelegation?.finalityProviderBtcPksHex,
+    getRegisteredFinalityProvider,
+    logger,
+  ]);
+
+  // Initialize form data when modal opens
+  useEffect(() => {
+    if (open && formData && !formData.feeRate) {
+      const updatedFormData: StakingExpansionFormData = {
+        ...formData,
+        feeRate: defaultFeeRate,
+        // Only set stakingTimelock if we have a default value (fixed term mode)
+        // In variable term mode, user must explicitly choose the term
+        stakingTimelock: defaultStakingTimeBlocks || formData.stakingTimelock,
+      };
+      setFormData(updatedFormData);
+    }
+  }, [open, formData, defaultFeeRate, defaultStakingTimeBlocks, setFormData]);
+
+  // Initialize modal data loading when opened
+  useEffect(() => {
+    if (open) {
+      // Start with BSN modal for expansion flow
+      setStakingModalPage(StakingModalPage.BSN);
+    } else {
+      setStakingModalPage(StakingModalPage.DEFAULT);
+      setSelectedBsnId(undefined);
+    }
+  }, [open, setStakingModalPage, setSelectedBsnId]);
+
+  const handleClose = useCallback(() => {
+    reset();
+    setSelectedBsnFps({});
+    setStakingModalPage(StakingModalPage.DEFAULT);
+    setSelectedBsnId(undefined);
+    onClose();
+  }, [reset, onClose, setStakingModalPage, setSelectedBsnId]);
+
+  // BSN selection handler - triggers FP modal
+  const handleBsnSelect = useCallback(
+    (bsnId: string) => {
+      setSelectedBsnId(bsnId);
+    },
+    [setSelectedBsnId],
+  );
+
+  // Move to FP selection for the selected BSN
+  const handleBsnNext = useCallback(() => {
+    setStakingModalPage(StakingModalPage.FINALITY_PROVIDER);
+  }, [setStakingModalPage]);
+
+  // Return to BSN selection from FP modal
+  const handleFpBack = useCallback(() => {
+    setStakingModalPage(StakingModalPage.BSN);
+  }, [setStakingModalPage]);
+
+  // Add BSN+FP pair and return to BSN selection
+  const handleFpAdd = useCallback(
+    (bsnId: string, fpPkHex: string) => {
+      setSelectedBsnFps((prev) => ({
+        ...prev,
+        [bsnId]: fpPkHex,
+      }));
+      // Return to BSN selection to add more or expand
+      setStakingModalPage(StakingModalPage.BSN);
+      setSelectedBsnId(undefined);
+    },
+    [setStakingModalPage, setSelectedBsnId],
+  );
+
+  // Remove BSN+FP pair
+  const handleRemoveBsnFp = useCallback((bsnId: string) => {
+    setSelectedBsnFps((prev) => {
+      const newSelection = { ...prev };
+      delete newSelection[bsnId];
+      return newSelection;
+    });
+  }, []);
+
+  const handleExpand = useCallback(async () => {
+    if (!formData) return;
+
+    // Calculate fee amount
+    setIsCalculatingFee(true);
+    try {
+      const updatedFormData: StakingExpansionFormData = {
+        ...formData,
+        selectedBsnFps,
+        feeRate: defaultFeeRate,
+      };
+
+      const feeAmount = await calculateExpansionFeeAmount(updatedFormData);
+      const finalFormData: StakingExpansionFormData = {
+        ...updatedFormData,
+        feeAmount,
+      };
+
+      // Close the modal and go to preview
+      handleClose();
+      displayExpansionPreview(finalFormData);
+    } catch (error) {
+      logger.error("Failed to calculate expansion fee", { error });
+    } finally {
+      setIsCalculatingFee(false);
+    }
+  }, [
+    formData,
+    selectedBsnFps,
+    defaultFeeRate,
+    calculateExpansionFeeAmount,
+    displayExpansionPreview,
+    handleClose,
+    logger,
+  ]);
+
+  // Don't render until we have form data
+  if (!open || !formData) {
+    return null;
+  }
+
+  const availableSlots = getAvailableBsnSlots();
+  const selectedCount = Object.keys(selectedBsnFps).length;
+  const canExpand = selectedCount > 0 && selectedCount <= availableSlots;
+
+  return (
+    <Fragment>
+      {/* Reuse existing ChainSelectionModal for BSN selection */}
+      <ChainSelectionModal
+        loading={bsnLoading}
+        open={stakingModalPage === StakingModalPage.BSN}
+        bsns={bsnList}
+        activeBsnId={selectedBsnId}
+        selectedBsns={selectedBsnFps}
+        existingBsns={existingBsnFps}
+        onNext={handleBsnNext}
+        onClose={handleClose}
+        onSelect={handleBsnSelect}
+        onRemove={handleRemoveBsnFp}
+        isExpansionMode={true}
+        onExpand={canExpand ? handleExpand : undefined}
+        expandLoading={isCalculatingFee}
+      />
+
+      {/* Reuse existing FinalityProviderModal for FP selection */}
+      <FinalityProviderModal
+        selectedBsnId={selectedBsnId}
+        open={stakingModalPage === StakingModalPage.FINALITY_PROVIDER}
+        onClose={handleClose}
+        onAdd={handleFpAdd}
+        onBack={handleFpBack}
+      />
+    </Fragment>
+  );
+};

--- a/src/ui/common/components/StakingExpansion/StakingExpansionModalSystem.tsx
+++ b/src/ui/common/components/StakingExpansion/StakingExpansionModalSystem.tsx
@@ -1,0 +1,153 @@
+import { useFormContext } from "@babylonlabs-io/core-ui";
+import { useMemo } from "react";
+
+import { CancelFeedbackModal } from "@/ui/common/components/Modals/CancelFeedbackModal";
+import { PreviewModal } from "@/ui/common/components/Modals/PreviewModal";
+import { SignModal } from "@/ui/common/components/Modals/SignModal/SignModal";
+import { StakeModal } from "@/ui/common/components/Modals/StakeModal";
+import { SuccessFeedbackModal } from "@/ui/common/components/Modals/SuccessFeedbackModal";
+import { VerificationModal } from "@/ui/common/components/Modals/VerificationModal";
+import { useStakingExpansionService } from "@/ui/common/hooks/services/useStakingExpansionService";
+import { useAppState } from "@/ui/common/state";
+import { useDelegationV2State } from "@/ui/common/state/DelegationV2State";
+import { FinalityProviderBsnState } from "@/ui/common/state/FinalityProviderBsnState";
+import { useFinalityProviderState } from "@/ui/common/state/FinalityProviderState";
+import { useStakingExpansionState } from "@/ui/common/state/StakingExpansionState";
+import { StakingExpansionStep } from "@/ui/common/state/StakingExpansionTypes";
+
+import { SignDetailsModal } from "../Modals/SignDetailsModal";
+
+import { StakingExpansionModal } from "./StakingExpansionModal";
+
+const EOI_INDEXES: Record<string, number> = {
+  "eoi-staking-slashing": 1,
+  "eoi-unbonding-slashing": 2,
+  "eoi-proof-of-possession": 3,
+  "eoi-sign-bbn": 4,
+};
+
+const VERIFICATION_STEPS: Record<string, 1 | 2> = {
+  "eoi-send-bbn": 1,
+  verifying: 2,
+};
+
+function StakingExpansionModalSystemInner() {
+  const {
+    processing,
+    step,
+    formData,
+    verifiedDelegation,
+    reset: resetState,
+    expansionStepOptions,
+  } = useStakingExpansionState();
+
+  const { getRegisteredFinalityProvider } = useFinalityProviderState();
+  const { networkInfo } = useAppState();
+  const { createExpansionEOI, stakeDelegationExpansion } =
+    useStakingExpansionService();
+  const { reset: resetForm, trigger: revalidateForm } = useFormContext() || {
+    reset: () => {},
+    trigger: () => {},
+  };
+
+  const { delegationV2StepOptions, setDelegationV2StepOptions } =
+    useDelegationV2State();
+  const detailsModalTitle =
+    (delegationV2StepOptions?.type as string) ||
+    "Expansion Transaction Details";
+
+  // Get first finality provider for preview display
+  const fp = useMemo(() => {
+    if (!formData || !Object.keys(formData.selectedBsnFps).length) return null;
+    const firstFpPkHex = Object.values(formData.selectedBsnFps)[0];
+    return getRegisteredFinalityProvider(firstFpPkHex);
+  }, [formData, getRegisteredFinalityProvider]);
+
+  // Get unbonding fee from network parameters (same as regular staking)
+  const unbondingFeeSat = useMemo(() => {
+    const latestParam = networkInfo?.params.bbnStakingParams?.latestParam;
+    return latestParam?.unbondingFeeSat || 0;
+  }, [networkInfo]);
+
+  if (!step) {
+    return null;
+  }
+
+  const handleClose = () => {
+    resetState();
+    setDelegationV2StepOptions?.(undefined);
+  };
+
+  return (
+    <>
+      {step === StakingExpansionStep.BSN_FP_SELECTION && (
+        <StakingExpansionModal open onClose={handleClose} />
+      )}
+      {step === StakingExpansionStep.PREVIEW && formData && fp && (
+        <PreviewModal
+          open
+          processing={processing}
+          finalityProvider={fp.description.moniker}
+          finalityProviderAvatar={fp.description.identity}
+          stakingAmountSat={formData.originalDelegation.stakingAmount}
+          stakingTimelock={formData.stakingTimelock}
+          stakingFeeSat={formData.feeAmount}
+          feeRate={formData.feeRate}
+          unbondingFeeSat={unbondingFeeSat}
+          onClose={handleClose}
+          onSign={async () => {
+            await createExpansionEOI(formData);
+            resetForm();
+            revalidateForm();
+          }}
+        />
+      )}
+      {Boolean(EOI_INDEXES[step]) && (
+        <SignModal
+          open
+          processing={processing}
+          step={EOI_INDEXES[step]}
+          title="Staking Expansion"
+          options={expansionStepOptions}
+        />
+      )}
+      {Boolean(VERIFICATION_STEPS[step]) && (
+        <VerificationModal
+          open
+          processing={processing}
+          step={VERIFICATION_STEPS[step]}
+        />
+      )}
+      {verifiedDelegation && (
+        <StakeModal
+          open={step === StakingExpansionStep.VERIFIED}
+          processing={processing}
+          onSubmit={() => stakeDelegationExpansion(verifiedDelegation)}
+          onClose={handleClose}
+        />
+      )}
+      <SuccessFeedbackModal
+        open={step === StakingExpansionStep.FEEDBACK_SUCCESS}
+        onClose={handleClose}
+      />
+      <CancelFeedbackModal
+        open={step === StakingExpansionStep.FEEDBACK_CANCEL}
+        onClose={handleClose}
+      />
+      <SignDetailsModal
+        open={Boolean(delegationV2StepOptions) && processing}
+        onClose={() => setDelegationV2StepOptions?.(undefined)}
+        details={delegationV2StepOptions}
+        title={detailsModalTitle}
+      />
+    </>
+  );
+}
+
+export function StakingExpansionModalSystem() {
+  return (
+    <FinalityProviderBsnState>
+      <StakingExpansionModalSystemInner />
+    </FinalityProviderBsnState>
+  );
+}

--- a/src/ui/common/state/StakingExpansionTypes.ts
+++ b/src/ui/common/state/StakingExpansionTypes.ts
@@ -1,10 +1,12 @@
 import type { EventData } from "@babylonlabs-io/btc-staking-ts";
 
 import { BaseStakingStep, EOIStep } from "@/ui/common/constants";
+import type { Bsn } from "@/ui/common/types/bsn";
 import type {
   DelegationV2,
   DelegationWithFP,
 } from "@/ui/common/types/delegationsV2";
+import type { FinalityProvider } from "@/ui/common/types/finalityProviders";
 
 /**
  * Enum representing the different steps in the staking expansion workflow.
@@ -92,3 +94,51 @@ export interface StakingExpansionState {
   /** Check if expansion is possible for a given delegation */
   canExpand: (delegation: { finalityProviderBtcPksHex: string[] }) => boolean;
 }
+
+/**
+ * Extended BSN interface for expansion mode that includes status information
+ */
+export interface BsnWithStatus extends Bsn {
+  /** Whether this BSN already has a finality provider in the original delegation */
+  isExisting: boolean;
+  /** Whether this BSN has been selected for the current expansion */
+  isSelected: boolean;
+  /** The finality provider public key hex associated with this BSN */
+  fpPkHex?: string;
+}
+
+/**
+ * Display data structure for BSNs in expansion modal
+ */
+export interface ExpansionBsnDisplay {
+  babylon: BsnWithStatus | null;
+  external: BsnWithStatus[];
+}
+
+/**
+ * Helper function to get finality provider information for a BSN
+ */
+export interface BsnFinalityProviderInfo {
+  fpPkHex?: string;
+  provider?: FinalityProvider;
+  title: string;
+  isDisabled: boolean;
+  isExisting: boolean;
+}
+
+/**
+ * Validation helper for StakingExpansionFormData
+ */
+export const validateExpansionFormData = (
+  data: Partial<StakingExpansionFormData>,
+): data is StakingExpansionFormData => {
+  return !!(
+    data.originalDelegation &&
+    data.selectedBsnFps &&
+    Object.keys(data.selectedBsnFps).length > 0 &&
+    data.feeRate &&
+    data.feeRate > 0 &&
+    data.stakingTimelock &&
+    data.stakingTimelock > 0
+  );
+};


### PR DESCRIPTION
Wires up the `state/service` + `btc-staking-ts` + `bsn/fp modals` to do the main action - stake expand
Currently only one path is supported - add bsn/fp + renew the timelock

Closes #1328 