### PR TITLE
fix: should use lcd instead of rpc url for baby client GET requests

### DIFF
--- a/src/infrastructure/babylon.ts
+++ b/src/infrastructure/babylon.ts
@@ -3,7 +3,7 @@ import { createLCDClient, txs, utils } from "@babylonlabs-io/babylon-proto-ts";
 import config from "./config";
 
 export default {
-  client: await createLCDClient({ url: config.babylon.rpcUrl }),
+  client: await createLCDClient({ url: config.babylon.lcdUrl }),
   txs,
   utils,
 };

--- a/src/ui/baby/hooks/services/useWalletService.ts
+++ b/src/ui/baby/hooks/services/useWalletService.ts
@@ -5,5 +5,5 @@ export function useWalletService() {
   const { bech32Address } = useCosmosWallet();
   const { data: balance = 0 } = useBabyBalance(bech32Address);
 
-  return { balance };
+  return { balance, bech32Address };
 }


### PR DESCRIPTION
Should use lcd endpoint instead of rpc for baby staking fetching operations