### PR TITLE
feat: integrate UnavailableWarning component into FinalityProviderModal

### DIFF
--- a/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal.tsx
@@ -9,6 +9,8 @@ import { useState } from "react";
 import { ResponsiveDialog } from "@/ui/common/components/Modals/ResponsiveDialog";
 import { FinalityProviders } from "@/ui/common/components/Multistaking/FinalityProviderField/FinalityProviders";
 
+import { UnavailableWarning } from "../MultistakingForm/UnavailableWarning";
+
 interface Props {
   open: boolean;
   defaultFinalityProvider?: string;
@@ -41,14 +43,15 @@ export const FinalityProviderModal = ({
         className="text-accent-primary"
       />
 
-      <DialogBody className="flex flex-col mb-4 mt-4 text-accent-primary">
-        <div>
+      <DialogBody className="flex flex-col mb-4 mt-4 text-accent-primary gap-4">
+        <div className="text-accent-secondary">
           Finality Providers play a key role in securing Proof-of-Stake networks
           by validating and finalising transactions. Select one to delegate your
           stake.
         </div>
+        <UnavailableWarning />
         <div
-          className="overflow-x-auto flex flex-col gap-2 mt-10"
+          className="overflow-x-auto flex flex-col gap-2"
           style={{ maxHeight: "min(60vh, 500px)" }}
         >
           <FinalityProviders selectedFP={selectedFP} onChange={setSelectedFp} />

--- a/src/ui/common/components/Multistaking/MultistakingForm/MultistakingFormContent.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/MultistakingFormContent.tsx
@@ -11,7 +11,6 @@ import { FinalityProvidersSection } from "./FinalityProvidersSection";
 import { FormAlert } from "./FormAlert";
 import { StakingFeesSection } from "./StakingFeesSection";
 import { SubmitButton } from "./SubmitButton";
-import { UnavailableWarning } from "./UnavailableWarning";
 
 export function MultistakingFormContent() {
   const { address } = useBTCWallet();
@@ -41,7 +40,6 @@ export function MultistakingFormContent() {
         <AuthGuard fallback={<ConnectButton />}>
           <SubmitButton />
         </AuthGuard>
-        <UnavailableWarning />
 
         <FormAlert
           address={address}

--- a/src/ui/common/components/Multistaking/MultistakingForm/UnavailableWarning.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/UnavailableWarning.tsx
@@ -1,4 +1,4 @@
-import { Warning } from "@babylonlabs-io/core-ui";
+import { WarningIcon } from "@babylonlabs-io/core-ui";
 
 import { useStakingExpansionAllowList } from "@/ui/common/hooks/useStakingExpansionAllowList";
 
@@ -8,10 +8,11 @@ export function UnavailableWarning() {
   // If allow list is active, show warning about multi-staking being unavailable
   if (isMultiStakingAllowListInForce) {
     return (
-      <Warning className="mt-2">
+      <div className="flex items-center text-sm gap-2">
+        <WarningIcon className="w-[14px] h-[14px]" />
         New stakes can only delegate to Babylon Genesis. Multi-Staking is
         currently unavailable due to allow list restrictions.
-      </Warning>
+      </div>
     );
   }
 

--- a/src/ui/common/hooks/useStakingExpansionAllowList.ts
+++ b/src/ui/common/hooks/useStakingExpansionAllowList.ts
@@ -1,4 +1,5 @@
 import { useNetworkInfo } from "@/ui/common/hooks/client/api/useNetworkInfo";
+import FeatureFlagService from "@/ui/legacy/utils/FeatureFlagService";
 
 /**
  * Hook to determine if the allow list is active and expose allow list data
@@ -8,6 +9,7 @@ export function useStakingExpansionAllowList() {
   const { data: networkInfo } = useNetworkInfo();
 
   const isMultiStakingAllowListInForce =
+    FeatureFlagService.IsPhase3Enabled &&
     networkInfo?.stakingStatus?.isMultiStakingAllowListInForce;
 
   return {


### PR DESCRIPTION
This pull request updates how the "Multi-Staking Unavailable" warning is displayed and where it appears in the UI. The warning is now shown inside the `FinalityProviderModal` instead of the main multistaking form

<img width="500" height="579" alt="Screenshot 2025-08-07 at 9 03 04 PM" src="https://github.com/user-attachments/assets/6022592c-3ce9-4139-81dc-12c10baa6128" />
<img width="850" height="780" alt="Screenshot 2025-08-07 at 9 02 57 PM" src="https://github.com/user-attachments/assets/efc743fd-a9f5-44f3-bf79-8afedc48a498" />
