### PR TITLE
fix: disable babylon genesis

### DIFF
--- a/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
+++ b/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
@@ -13,6 +13,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { FinalityProviderModal } from "@/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal";
 import { ExpansionChainSelectionModal } from "@/ui/common/components/StakingExpansion/ExpansionChainSelectionModal";
 import { IS_FIXED_TERM_FIELD } from "@/ui/common/config";
+import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
 import { useNetworkFees } from "@/ui/common/hooks/client/api/useNetworkFees";
 import { useStakingExpansionService } from "@/ui/common/hooks/services/useStakingExpansionService";
 import { useLogger } from "@/ui/common/hooks/useLogger";
@@ -25,6 +26,9 @@ import { useFinalityProviderState } from "@/ui/common/state/FinalityProviderStat
 import { useStakingExpansionState } from "@/ui/common/state/StakingExpansionState";
 import { type StakingExpansionFormData } from "@/ui/common/state/StakingExpansionTypes";
 import { getFeeRateFromMempool } from "@/ui/common/utils/getFeeRateFromMempool";
+
+// Get the Babylon Genesis BSN ID
+const BSN_ID = getNetworkConfigBBN().chainId;
 
 interface StakingExpansionModalProps {
   open: boolean;
@@ -115,10 +119,11 @@ export const StakingExpansionModal = ({
         }
 
         const fp = getRegisteredFinalityProvider(fpPkHex);
-        if (fp && fp.bsnId) {
-          pairs[fp.bsnId] = fpPkHex;
+        if (fp) {
+          // Use bsnId if available, otherwise it's a Babylon Genesis FP (bsnId is null)
+          const bsnId = fp.bsnId || BSN_ID;
+          pairs[bsnId] = fpPkHex;
         }
-        // Note: If FP is not found or has no bsnId, we skip it (no action needed)
       });
 
       return pairs;


### PR DESCRIPTION
Babylon FPs check to make it disabled when selecting for staking expansion

Closes https://github.com/babylonlabs-io/simple-staking/issues/1386