### PR TITLE
fix: should not show top nav when baby staking FF is off

### DIFF
--- a/src/ui/common/components/Header/Header.tsx
+++ b/src/ui/common/components/Header/Header.tsx
@@ -19,14 +19,14 @@ export const Header = () => {
           <SmallLogo />
         </div>
 
-        <div className="absolute left-1/2 transform -translate-x-1/2">
-          <Nav>
-            <NavItem title="BTC Staking" to="/btc" />
-            {FF.IsBabyStakingEnabled && (
+        {FF.IsBabyStakingEnabled && (
+          <div className="absolute left-1/2 transform -translate-x-1/2">
+            <Nav>
+              <NavItem title="BTC Staking" to="/btc" />
               <NavItem title="BABY Staking" to="/baby" />
-            )}
-          </Nav>
-        </div>
+            </Nav>
+          </div>
+        )}
 
         <div className="flex items-center gap-4">
           <Connect loading={loading} onConnect={open} />


### PR DESCRIPTION
We will hide the top navigation if BABY staking FF is false