### PR TITLE
feat: expansion - stop data loading on history modal open

### DIFF
--- a/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
+++ b/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
@@ -4,7 +4,6 @@ import {
   AccordionSummary,
   Text,
 } from "@babylonlabs-io/core-ui";
-import { useState } from "react";
 import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
 
 import iconBSNFp from "@/ui/common/assets/expansion-bsn-fp.svg";
@@ -25,12 +24,17 @@ interface StakeExpansionSectionProps {
 export function StakeExpansionSection({
   delegation,
 }: StakeExpansionSectionProps) {
-  const { goToStep, setFormData, processing, maxFinalityProviders, canExpand } =
-    useStakingExpansionState();
+  const {
+    goToStep,
+    setFormData,
+    processing,
+    maxFinalityProviders,
+    canExpand,
+    expansionHistoryModalOpen,
+    setExpansionHistoryModalOpen,
+  } = useStakingExpansionState();
   const { delegations } = useDelegationV2State();
   const { getHistoryCount } = useExpansionHistoryService();
-  const [expansionHistoryModalOpen, setExpansionHistoryModalOpen] =
-    useState(false);
 
   const currentBsnCount = delegation.finalityProviderBtcPksHex.length;
   const canExpandDelegation = canExpand(delegation);

--- a/src/ui/common/hooks/services/useDelegationService.ts
+++ b/src/ui/common/hooks/services/useDelegationService.ts
@@ -82,12 +82,11 @@ export function useDelegationService() {
   const { isFetching: isFPLoading, finalityProviderMap } =
     useFinalityProviderState();
 
-  const { step } = useStakingExpansionState();
-  const isStakingExpansionModalOpen = Boolean(step);
+  const { isExpansionModalOpen } = useStakingExpansionState();
 
-  // Stop loading when staking expansion is working
+  // Stop loading when any expansion modal is open
   const isLoading =
-    (isDelegationLoading || isFPLoading) && !isStakingExpansionModalOpen;
+    (isDelegationLoading || isFPLoading) && !isExpansionModalOpen;
 
   const delegationsWithFP = useMemo(
     () =>

--- a/src/ui/common/state/StakingExpansionState.tsx
+++ b/src/ui/common/state/StakingExpansionState.tsx
@@ -40,6 +40,9 @@ const { StateProvider, useState: useStakingExpansionState } =
     reset: () => {},
     expansionStepOptions: undefined,
     setExpansionStepOptions: () => {},
+    expansionHistoryModalOpen: false,
+    setExpansionHistoryModalOpen: () => {},
+    isExpansionModalOpen: false,
     maxFinalityProviders: DEFAULT_MAX_FINALITY_PROVIDERS,
     getAvailableBsnSlots: () => 0,
     canAddMoreBsns: () => false,
@@ -67,6 +70,8 @@ export function StakingExpansionState({ children }: PropsWithChildren) {
   const [expansionStepOptions, setExpansionStepOptions] = useState<
     EventData | undefined
   >();
+  const [expansionHistoryModalOpen, setExpansionHistoryModalOpen] =
+    useState(false);
 
   useEffect(() => {
     const unsubscribe = eventBus.on("delegation:expand", (options) => {
@@ -102,6 +107,7 @@ export function StakingExpansionState({ children }: PropsWithChildren) {
     setStep(undefined);
     setVerifiedDelegation(undefined);
     setExpansionStepOptions(undefined);
+    setExpansionHistoryModalOpen(false);
   }, []);
 
   /**
@@ -134,6 +140,9 @@ export function StakingExpansionState({ children }: PropsWithChildren) {
     [maxFinalityProviders],
   );
 
+  // Computed state: true when any expansion-related modal is open
+  const isExpansionModalOpen = Boolean(step) || expansionHistoryModalOpen;
+
   const state: StakingExpansionState = {
     hasError,
     processing,
@@ -148,6 +157,9 @@ export function StakingExpansionState({ children }: PropsWithChildren) {
     reset,
     expansionStepOptions,
     setExpansionStepOptions,
+    expansionHistoryModalOpen,
+    setExpansionHistoryModalOpen,
+    isExpansionModalOpen,
     maxFinalityProviders,
     getAvailableBsnSlots,
     canAddMoreBsns,

--- a/src/ui/common/state/StakingExpansionTypes.ts
+++ b/src/ui/common/state/StakingExpansionTypes.ts
@@ -67,6 +67,10 @@ export interface StakingExpansionState {
   verifiedDelegation?: DelegationV2;
   /** Event data options for current step */
   expansionStepOptions: EventData | undefined;
+  /** Whether the expansion history modal is open */
+  expansionHistoryModalOpen: boolean;
+  /** Computed state: true when any expansion-related modal is open */
+  isExpansionModalOpen: boolean;
 
   // Core actions
   /** Navigate to a specific step in the expansion flow */
@@ -81,6 +85,8 @@ export interface StakingExpansionState {
   reset: () => void;
   /** Set options for current expansion step */
   setExpansionStepOptions: (options?: EventData) => void;
+  /** Set expansion history modal open state */
+  setExpansionHistoryModalOpen: (open: boolean) => void;
 
   // Network configuration
   /** Maximum number of finality providers allowed based on network parameters */


### PR DESCRIPTION
- stops data loading when `expansion history` modal is open

Closes https://github.com/babylonlabs-io/simple-staking/issues/1408