### PR TITLE
feat: adds support for optimistic pending state for BABY delegations

### DIFF
--- a/src/ui/baby/components/ActivityList/index.tsx
+++ b/src/ui/baby/components/ActivityList/index.tsx
@@ -147,7 +147,7 @@ export function BabyActivityList() {
       <div className="space-y-4">
         {activityItems.map(({ delegation, data }) => (
           <BabyActivityCard
-            key={`${delegation.validator.address}-${delegation.amount.toString()}-${delegation.status}`}
+            key={`${delegation.validator.address}-${delegation.amount.toString()}-${delegation.status}${delegation.timestamp ? `-${delegation.timestamp}` : ""}`}
             activityData={data}
           />
         ))}

--- a/src/ui/baby/components/ActivityList/index.tsx
+++ b/src/ui/baby/components/ActivityList/index.tsx
@@ -21,6 +21,7 @@ interface UnbondingModalState {
 
 export function BabyActivityList() {
   const { loading, delegations, unbond } = useDelegationState();
+
   const [unbondingModal, setUnbondingModal] = useState<UnbondingModalState>({
     isOpen: false,
     delegation: null,
@@ -54,19 +55,28 @@ export function BabyActivityList() {
     return delegations.map((delegation) => {
       const formattedAmount = babylon.utils.ubbnToBaby(delegation.amount);
       const isUnbonding = delegation.status === "unbonding";
+      const isPending = delegation.status === "pending";
+
+      let statusText = "Active";
+      if (isUnbonding) {
+        statusText = "Unbonding";
+      } else if (isPending) {
+        statusText = "Pending";
+      }
 
       return {
         delegation,
         data: {
           icon: logo,
           formattedAmount: `${formattedAmount} ${coinSymbol}`,
-          primaryAction: isUnbonding
-            ? undefined
-            : {
-                label: "Unbond",
-                variant: "contained" as const,
-                onClick: () => openUnbondingModal(delegation),
-              },
+          primaryAction:
+            isUnbonding || isPending
+              ? undefined
+              : {
+                  label: "Unbond",
+                  variant: "contained" as const,
+                  onClick: () => openUnbondingModal(delegation),
+                },
           details: [],
           optionalDetails: [
             {
@@ -81,7 +91,7 @@ export function BabyActivityList() {
             },
             {
               label: "Status",
-              value: isUnbonding ? "Unbonding" : "Active",
+              value: statusText,
             },
             {
               label: "Voting Power",
@@ -96,6 +106,14 @@ export function BabyActivityList() {
                         ? `${babylon.utils.ubbnToBaby(delegation.unbondingInfo.amount)} ${coinSymbol} - Processing`
                         : `${babylon.utils.ubbnToBaby(delegation.unbondingInfo.amount)} ${coinSymbol} in ${formatTimeRemaining(delegation.unbondingInfo.completionTime)}${delegation.unbondingInfo.statusSuffix || ""}`
                       : "In progress...",
+                  },
+                ]
+              : []),
+            ...(isPending
+              ? [
+                  {
+                    label: "Transaction",
+                    value: "Processing on blockchain...",
                   },
                 ]
               : []),
@@ -129,7 +147,7 @@ export function BabyActivityList() {
       <div className="space-y-4">
         {activityItems.map(({ delegation, data }) => (
           <BabyActivityCard
-            key={delegation.validator.address}
+            key={`${delegation.validator.address}-${delegation.amount.toString()}-${delegation.status}`}
             activityData={data}
           />
         ))}

--- a/src/ui/baby/hooks/services/useDelegationService.ts
+++ b/src/ui/baby/hooks/services/useDelegationService.ts
@@ -64,6 +64,8 @@ const OPTIMISTIC_STAKING_KEY = "baby-optimistic-stakings";
 const UNBONDING_PERIOD_MS = 21 * 24 * 60 * 60 * 1000;
 const POLLING_INTERVAL_MS = 15000;
 const OPTIMISTIC_TIMEOUT_MS = 3 * 60 * 1000;
+const STAKING_CONFIRMATION_TIMEOUT_MS = 30000;
+const STAKING_RESET_TIMEOUT_MS = 5000;
 
 function getStatusSuffix(age: number, ageMinutes: number): string {
   if (age > 2 * 60 * 1000) {
@@ -153,7 +155,7 @@ export function useDelegationService() {
       }),
     );
 
-    if (optimisticStakings.length > 0 || !isStakingRef.current) {
+    if (optimisticStakings.length > 0) {
       localStorage.setItem(
         OPTIMISTIC_STAKING_KEY,
         JSON.stringify(storageFormat),
@@ -346,7 +348,7 @@ export function useDelegationService() {
       const { validatorAddress } = optimisticStaking;
 
       const age = Date.now() - optimisticStaking.timestamp;
-      const isConfirmedInAPI = age > 30000;
+      const isConfirmedInAPI = age > STAKING_CONFIRMATION_TIMEOUT_MS;
 
       if (isConfirmedInAPI) {
         optimisticStakingsToRemove.push(optimisticStaking);
@@ -429,7 +431,7 @@ export function useDelegationService() {
 
         setTimeout(() => {
           isStakingRef.current = false;
-        }, 5000);
+        }, STAKING_RESET_TIMEOUT_MS);
 
         return result;
       } catch (error) {

--- a/src/ui/baby/hooks/services/useDelegationService.ts
+++ b/src/ui/baby/hooks/services/useDelegationService.ts
@@ -31,6 +31,7 @@ export interface Delegation {
   coin: "ubbn";
   status?: DelegationStatus;
   unbondingInfo?: UnbondingInfo;
+  timestamp?: number;
 }
 
 interface OptimisticUnbonding {
@@ -362,6 +363,7 @@ export function useDelegationService() {
             amount: optimisticStaking.amount,
             coin: "ubbn" as const,
             status: "pending" as DelegationStatus,
+            timestamp: optimisticStaking.timestamp,
           };
           result.push(pendingDelegation);
         }

--- a/src/ui/baby/layout.tsx
+++ b/src/ui/baby/layout.tsx
@@ -2,7 +2,7 @@ import { useWalletConnect } from "@babylonlabs-io/wallet-connector";
 import { useEffect, useState } from "react";
 
 import { DelegationState } from "@/ui/baby/state/DelegationState";
-import { RewardState } from "@/ui/baby/state/RewardState";
+import { RewardState, useRewardState } from "@/ui/baby/state/RewardState";
 import { StakingState } from "@/ui/baby/state/StakingState";
 import { ValidatorState } from "@/ui/baby/state/ValidatorState";
 import { AuthGuard } from "@/ui/common/components/Common/AuthGuard";
@@ -15,7 +15,6 @@ import { useHealthCheck } from "@/ui/common/hooks/useHealthCheck";
 import { BabyActivityList } from "./components/ActivityList";
 import { RewardCard } from "./components/RewardCard";
 import { RewardsPreviewModal } from "./components/RewardPreviewModal";
-import { useRewardState } from "./state/RewardState";
 import StakingForm from "./widgets/StakingForm";
 
 type TabId = "stake" | "activity" | "rewards";
@@ -106,9 +105,9 @@ export default function BabyLayout() {
   );
 
   return (
-    <StakingState>
-      <ValidatorState>
-        <DelegationState>
+    <ValidatorState>
+      <DelegationState>
+        <StakingState>
           <RewardState>
             <Content>
               <AuthGuard fallback={fallbackContent}>
@@ -126,8 +125,8 @@ export default function BabyLayout() {
               </AuthGuard>
             </Content>
           </RewardState>
-        </DelegationState>
-      </ValidatorState>
-    </StakingState>
+        </StakingState>
+      </DelegationState>
+    </ValidatorState>
   );
 }

--- a/src/ui/baby/state/DelegationState.tsx
+++ b/src/ui/baby/state/DelegationState.tsx
@@ -13,10 +13,21 @@ interface UnbondProps {
   amount: string;
 }
 
+interface StakeProps {
+  validatorAddress: string;
+  amount: string | number;
+}
+
 interface ValidatorState {
   loading: boolean;
   delegations: Delegation[];
   unbond: (params: UnbondProps) => Promise<void>;
+  stake: (
+    params: StakeProps,
+  ) => Promise<{ txHash: string; gasUsed: string } | undefined>;
+  estimateStakingFee: (
+    params: Omit<StakeProps, "amount"> & { amount: number },
+  ) => Promise<number>;
 }
 
 const { StateProvider, useState: useDelegationState } =
@@ -24,12 +35,15 @@ const { StateProvider, useState: useDelegationState } =
     loading: false,
     delegations: [],
     unbond: async () => {},
+    stake: async () => undefined,
+    estimateStakingFee: async () => 0,
   });
 
 function DelegationState({ children }: PropsWithChildren) {
   const [processing, setProcessing] = useState(false);
 
-  const { loading, delegations, unstake } = useDelegationService();
+  const { loading, delegations, unstake, stake, estimateStakingFee } =
+    useDelegationService();
   const { handleError } = useError();
   const logger = useLogger();
 
@@ -60,8 +74,10 @@ function DelegationState({ children }: PropsWithChildren) {
       loading: processing || loading,
       delegations,
       unbond,
+      stake,
+      estimateStakingFee,
     }),
-    [processing, loading, delegations, unbond],
+    [processing, loading, delegations, unbond, stake, estimateStakingFee],
   );
 
   return <StateProvider value={context}>{children}</StateProvider>;

--- a/src/ui/baby/state/StakingState.tsx
+++ b/src/ui/baby/state/StakingState.tsx
@@ -2,9 +2,9 @@ import { type PropsWithChildren, useCallback, useMemo, useState } from "react";
 import { array, number, object, ObjectSchema, ObjectShape, string } from "yup";
 
 import babylon from "@/infrastructure/babylon";
-import { useDelegationService } from "@/ui/baby/hooks/services/useDelegationService";
 import { useValidatorService } from "@/ui/baby/hooks/services/useValidatorService";
 import { useWalletService } from "@/ui/baby/hooks/services/useWalletService";
+import { useDelegationState } from "@/ui/baby/state/DelegationState";
 import { validateDecimalPoints } from "@/ui/common/components/Staking/Form/validation/validation";
 import { useError } from "@/ui/common/context/Error/ErrorProvider";
 import { usePrice } from "@/ui/common/hooks/client/api/usePrices";
@@ -79,7 +79,8 @@ const { StateProvider, useState: useStakingState } =
 function StakingState({ children }: PropsWithChildren) {
   const [step, setStep] = useState<StakingStep>({ name: "initial" });
 
-  const { stake, estimateStakingFee } = useDelegationService();
+  const { stake, estimateStakingFee } = useDelegationState();
+
   const { validatorMap, loading } = useValidatorService();
   const { balance } = useWalletService();
   const { handleError } = useError();
@@ -188,10 +189,11 @@ function StakingState({ children }: PropsWithChildren) {
       const amount = step.data.amount;
       const validatorAddress = step.data.validator.address;
       const result = await stake({ amount, validatorAddress });
+      const txHash = result?.txHash || "";
       logger.info("Baby Staking: Stake", {
-        txHash: result?.txHash,
+        txHash,
       });
-      setStep({ name: "success", data: { txHash: result?.txHash } });
+      setStep({ name: "success", data: { txHash } });
     } catch (error: any) {
       handleError({ error });
       logger.error(error);

--- a/src/ui/common/types/delegations.ts
+++ b/src/ui/common/types/delegations.ts
@@ -24,7 +24,7 @@ export interface UnbondingTx {
   outputIndex: number;
 }
 
-export type DelegationStatus = "active" | "unbonding" | "unbonded";
+export type DelegationStatus = "active" | "unbonding" | "unbonded" | "pending";
 
 export const ACTIVE = "active";
 export const UNBONDING_REQUESTED = "unbonding_requested";


### PR DESCRIPTION
https://github.com/user-attachments/assets/9761ede5-3a90-4bb1-9329-25443f59c386


Implemented optimistic staking for BABY tokens. Stakes now appear immediately as "pending" in Activity tab while processing. Pending stakes automatically clear after 3 minutes or on transaction failure.