### PR TITLE
fix: remove duplicated tab titles

### DIFF
--- a/src/ui/baby/layout.tsx
+++ b/src/ui/baby/layout.tsx
@@ -2,7 +2,7 @@ import { useWalletConnect } from "@babylonlabs-io/wallet-connector";
 import { useEffect, useState } from "react";
 
 import { DelegationState } from "@/ui/baby/state/DelegationState";
-import { RewardState } from "@/ui/baby/state/RewardState";
+import { RewardState, useRewardState } from "@/ui/baby/state/RewardState";
 import { StakingState } from "@/ui/baby/state/StakingState";
 import { ValidatorState } from "@/ui/baby/state/ValidatorState";
 import { AuthGuard } from "@/ui/common/components/Common/AuthGuard";
@@ -15,7 +15,6 @@ import { useHealthCheck } from "@/ui/common/hooks/useHealthCheck";
 import { BabyActivityList } from "./components/ActivityList";
 import { RewardCard } from "./components/RewardCard";
 import { RewardsPreviewModal } from "./components/RewardPreviewModal";
-import { useRewardState } from "./state/RewardState";
 import StakingForm from "./widgets/StakingForm";
 
 type TabId = "stake" | "activity" | "rewards";
@@ -59,7 +58,7 @@ export default function BabyLayout() {
             id: "activity",
             label: "Activity",
             content: (
-              <Section title="Activity" titleClassName="md:text-[1.25rem]">
+              <Section>
                 <BabyActivityList />
               </Section>
             ),
@@ -68,7 +67,7 @@ export default function BabyLayout() {
             id: "rewards",
             label: "Rewards",
             content: (
-              <Section title="Rewards" titleClassName="md:text-[1.25rem]">
+              <Section>
                 <div className="h-[500px]">
                   <RewardCard />
                   <RewardsPreviewModal

--- a/src/ui/common/components/Activity/Activity.tsx
+++ b/src/ui/common/components/Activity/Activity.tsx
@@ -7,7 +7,7 @@ import { Delegations } from "../Delegations/Delegations";
 export function Activity() {
   return (
     <AuthGuard>
-      <Section title="Activity" titleClassName="md:text-[1.25rem] mt-10">
+      <Section>
         <Delegations />
         <ActivityList />
       </Section>

--- a/src/ui/common/components/FAQ/FAQ.tsx
+++ b/src/ui/common/components/FAQ/FAQ.tsx
@@ -10,7 +10,7 @@ export const FAQ = () => {
   const { coinName } = getNetworkConfigBTC();
 
   return (
-    <SectionContainer title="FAQs" titleClassName="md:text-[1.25rem] mt-10">
+    <SectionContainer titleClassName="md:text-[1.25rem] mt-10">
       <Card className="flex flex-col gap-4 divide-y bg-secondary-highlight !border-0">
         {questions(coinName).map((question) => (
           <Section

--- a/src/ui/common/components/Section/Section.tsx
+++ b/src/ui/common/components/Section/Section.tsx
@@ -5,7 +5,7 @@ import { twMerge } from "tailwind-merge";
 interface SectionProps {
   className?: string;
   titleClassName?: string;
-  title: string;
+  title?: string;
 }
 
 export function Section({


### PR DESCRIPTION
<img width="339" height="198" alt="image" src="https://github.com/user-attachments/assets/6af10593-1ebd-4498-bcd9-b9103d41dd06" />
 removing `activity` and `activity` showing twice 