### PR TITLE
fix: avoid refetch delegations when unbond, show processing modal whe…

### DIFF
--- a/src/ui/baby/components/ActivityList/index.tsx
+++ b/src/ui/baby/components/ActivityList/index.tsx
@@ -42,12 +42,11 @@ export function BabyActivityList() {
 
   const handleUnbond = async (amount: string) => {
     if (!unbondingModal.delegation) return;
-
+    closeUnbondingModal();
     await unbond({
       validatorAddress: unbondingModal.delegation.validator.address,
       amount,
     });
-    closeUnbondingModal();
   };
 
   const activityItems = useMemo(() => {
@@ -60,13 +59,14 @@ export function BabyActivityList() {
         data: {
           icon: logo,
           formattedAmount: `${formattedAmount} ${coinSymbol}`,
-          primaryAction: isUnbonding
-            ? undefined
-            : {
-                label: "Unbond",
-                variant: "contained" as const,
-                onClick: () => openUnbondingModal(delegation),
-              },
+          primaryAction:
+            formattedAmount > 0
+              ? {
+                  label: "Unbond",
+                  variant: "contained" as const,
+                  onClick: () => openUnbondingModal(delegation),
+                }
+              : undefined,
           details: [],
           optionalDetails: [
             {
@@ -78,14 +78,6 @@ export function BabyActivityList() {
               value: formatCommissionPercentage(
                 delegation.validator.commission,
               ),
-            },
-            {
-              label: "Status",
-              value: isUnbonding ? "Unbonding" : "Active",
-            },
-            {
-              label: "Voting Power",
-              value: `${(delegation.validator.votingPower * 100).toFixed(2)}%`,
             },
             ...(isUnbonding
               ? [

--- a/src/ui/baby/components/UnbondingModal/index.tsx
+++ b/src/ui/baby/components/UnbondingModal/index.tsx
@@ -14,9 +14,14 @@ import type { FieldValues } from "react-hook-form";
 
 import babylon from "@/infrastructure/babylon";
 import { AmountField } from "@/ui/baby/components/AmountField";
-import { type Delegation } from "@/ui/baby/state/DelegationState";
+import {
+  useDelegationState,
+  type Delegation,
+} from "@/ui/baby/state/DelegationState";
 import { createUnbondingValidationSchema } from "@/ui/baby/validation/unbondingValidation";
 import { ResponsiveDialog } from "@/ui/common/components/Modals/ResponsiveDialog";
+
+import { LoadingModal } from "../LoadingModal";
 
 interface UnbondingModalProps {
   open: boolean;
@@ -101,6 +106,8 @@ export const UnbondingModal = ({
   onClose,
   onSubmit,
 }: UnbondingModalProps) => {
+  const { step } = useDelegationState();
+
   const availableBalance = delegation ? delegation.amount : 0n;
   const availableBalanceInBaby = delegation
     ? babylon.utils.ubbnToBaby(delegation.amount)
@@ -111,6 +118,22 @@ export const UnbondingModal = ({
       createUnbondingValidationSchema(availableBalance, availableBalanceInBaby),
     [availableBalance, availableBalanceInBaby],
   );
+
+  if (step.name === "signing") {
+    return (
+      <LoadingModal
+        title="Signing in progress"
+        description="Please sign the unbonding transaction in your wallet to continue"
+      />
+    );
+  } else if (step.name === "loading") {
+    return (
+      <LoadingModal
+        title="Processing"
+        description="Babylon Genesis is processing your unbonding transaction"
+      />
+    );
+  }
 
   if (!open || !delegation) return null;
 

--- a/src/ui/baby/hooks/api/useUnbondingDelegations.ts
+++ b/src/ui/baby/hooks/api/useUnbondingDelegations.ts
@@ -1,3 +1,4 @@
+import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
 import { useCosmosWallet } from "@/ui/common/context/wallet/CosmosWalletProvider";
 import { useClientQuery } from "@/ui/common/hooks/client/useClient";
 
@@ -7,6 +8,7 @@ export function useUnbondingDelegations({
   enabled = true,
 }: { enabled?: boolean } = {}) {
   const { bech32Address } = useCosmosWallet();
+  const { lcdUrl } = getNetworkConfigBBN();
 
   return useClientQuery({
     queryKey: [BABY_UNBONDING_DELEGATIONS_KEY, bech32Address],
@@ -17,7 +19,7 @@ export function useUnbondingDelegations({
 
       try {
         const response = await fetch(
-          `${process.env.NEXT_PUBLIC_BABY_LCD_URL}/cosmos/staking/v1beta1/delegators/${bech32Address}/unbonding_delegations`,
+          `${lcdUrl}/cosmos/staking/v1beta1/delegators/${bech32Address}/unbonding_delegations`,
         );
 
         if (response.ok) {

--- a/src/ui/baby/state/DelegationState.tsx
+++ b/src/ui/baby/state/DelegationState.tsx
@@ -45,9 +45,12 @@ function DelegationState({ children }: PropsWithChildren) {
     async ({ validatorAddress, amount }: UnbondProps) => {
       try {
         setStep({ name: "signing" });
-        const signedTx = await unstake({ validatorAddress, amount });
+        const { signedTx, optimisticUnbonding } = await unstake({
+          validatorAddress,
+          amount,
+        });
         setStep({ name: "loading" });
-        const result = await sendTx(signedTx);
+        const result = await sendTx(signedTx, optimisticUnbonding);
         logger.info("Baby Staking: Unbond", {
           txHash: result?.txHash || "",
           validatorAddress,

--- a/src/ui/baby/widgets/StakingModal/index.tsx
+++ b/src/ui/baby/widgets/StakingModal/index.tsx
@@ -19,6 +19,12 @@ export function StakingModal() {
           onSubmit={submitForm}
         />
       )}
+      {step.name === "signing" && (
+        <LoadingModal
+          title="Signing in progress"
+          description="Please sign the transaction in your wallet to continue"
+        />
+      )}
       {step.name === "loading" && (
         <LoadingModal
           title="Processing"

--- a/src/ui/common/config/network/bbn.ts
+++ b/src/ui/common/config/network/bbn.ts
@@ -12,6 +12,7 @@ import { bbnTestnet } from "./bbn/testnet";
 interface ExtendedBBNConfig extends BBNConfig {
   displayUSD: boolean;
   logo: string;
+  lcdUrl: string;
 }
 
 const defaultNetwork = "devnet";
@@ -27,6 +28,7 @@ const config: Record<string, ExtendedBBNConfig> = {
     coinSymbol: "BABY",
     displayUSD: true,
     logo: babyLogo,
+    lcdUrl: bbnMainnet.rest,
   },
   canary: {
     chainId: bbnCanary.chainId,
@@ -37,6 +39,7 @@ const config: Record<string, ExtendedBBNConfig> = {
     coinSymbol: "BABY",
     displayUSD: true,
     logo: babyLogo,
+    lcdUrl: bbnCanary.rest,
   },
   devnet: {
     chainId: bbnDevnet.chainId,
@@ -47,6 +50,7 @@ const config: Record<string, ExtendedBBNConfig> = {
     coinSymbol: "tBABY",
     displayUSD: false,
     logo: babyLogo,
+    lcdUrl: bbnDevnet.rest,
   },
   bsnDevnet: {
     chainId: bbnBsnDevnet.chainId,
@@ -57,6 +61,7 @@ const config: Record<string, ExtendedBBNConfig> = {
     coinSymbol: "tBABY",
     displayUSD: false,
     logo: babyLogo,
+    lcdUrl: bbnBsnDevnet.rest,
   },
   edgeDevnet: {
     chainId: bbnEdgeDevnet.chainId,
@@ -67,6 +72,7 @@ const config: Record<string, ExtendedBBNConfig> = {
     coinSymbol: "tBABY",
     displayUSD: false,
     logo: babyLogo,
+    lcdUrl: bbnEdgeDevnet.rest,
   },
   testnet: {
     chainId: bbnTestnet.chainId,
@@ -77,6 +83,7 @@ const config: Record<string, ExtendedBBNConfig> = {
     coinSymbol: "tBABY",
     displayUSD: false,
     logo: babyLogo,
+    lcdUrl: bbnTestnet.rest,
   },
 };
 


### PR DESCRIPTION
1. Stop refetching when perform unbonding and staking. This is not needed
2. Show correct signing or in progress modal for unbonding and staking
3. Remove unused fields such as voting power in the activity card

<img width="1244" height="644" alt="image" src="https://github.com/user-attachments/assets/3a1033cc-7da0-47a5-a6a8-1342435e6115" />

<img width="891" height="619" alt="image" src="https://github.com/user-attachments/assets/232a8b1e-84c6-4dae-b8b3-5dcfc9479a0c" />

<img width="672" height="262" alt="image" src="https://github.com/user-attachments/assets/9cebe564-0f10-4cbc-99f0-ad211eaa5bad" />
