### PR TITLE
feat: expansion error catch

### DIFF
--- a/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
+++ b/src/ui/common/components/StakingExpansion/StakingExpansionModal.tsx
@@ -14,6 +14,7 @@ import { FinalityProviderModal } from "@/ui/common/components/Multistaking/Final
 import { ExpansionChainSelectionModal } from "@/ui/common/components/StakingExpansion/ExpansionChainSelectionModal";
 import { IS_FIXED_TERM_FIELD } from "@/ui/common/config";
 import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
+import { useError } from "@/ui/common/context/Error/ErrorProvider";
 import { useNetworkFees } from "@/ui/common/hooks/client/api/useNetworkFees";
 import { useStakingExpansionService } from "@/ui/common/hooks/services/useStakingExpansionService";
 import { useLogger } from "@/ui/common/hooks/useLogger";
@@ -69,6 +70,7 @@ export const StakingExpansionModal = ({
     useStakingExpansionService();
   const { networkInfo } = useAppState();
   const logger = useLogger();
+  const { handleError } = useError();
 
   // Calculate the default staking timelock using the same logic as regular staking
   const defaultStakingTimeBlocks = useMemo(() => {
@@ -235,8 +237,9 @@ export const StakingExpansionModal = ({
       handleClose();
       displayExpansionPreview(finalFormData);
     } catch (error) {
-      logger.error(new Error("Failed to calculate expansion fee"), {
-        data: { error: String(error) },
+      handleError({
+        error: error instanceof Error ? error : new Error(String(error)),
+        displayOptions: { showModal: true },
       });
     } finally {
       setIsCalculatingFee(false);
@@ -248,7 +251,7 @@ export const StakingExpansionModal = ({
     calculateExpansionFeeAmount,
     displayExpansionPreview,
     handleClose,
-    logger,
+    handleError,
   ]);
 
   // Don't render until we have form data

--- a/src/ui/common/errors/codes.ts
+++ b/src/ui/common/errors/codes.ts
@@ -16,6 +16,7 @@ export const ERROR_CODES = {
   TRANSACTION_PREPARATION_ERROR: "TRANSACTION_PREPARATION_ERROR", // Errors building the transaction (e.g., fee estimation issues)
   TRANSACTION_SUBMISSION_ERROR: "TRANSACTION_SUBMISSION_ERROR", // Errors sending/broadcasting the transaction via wallet or directly
   TRANSACTION_VERIFICATION_ERROR: "TRANSACTION_VERIFICATION_ERROR", // Errors confirming transaction status (not found, hash mismatch, not eligible)
+  STAKING_EXPANSION_FEE_ERROR: "STAKING_EXPANSION_FEE_ERROR", // Errors calculating fees for staking expansion transactions
 
   // --- Staking Logic Errors ---
   DELEGATION_LOGIC_ERROR: "DELEGATION_LOGIC_ERROR", // Errors in delegation selection, missing covenant signatures, finality provider issues

--- a/src/ui/common/hooks/services/useStakingExpansionService.ts
+++ b/src/ui/common/hooks/services/useStakingExpansionService.ts
@@ -45,22 +45,6 @@ const getCovenantExpansionSignatures = (delegation: any) => {
 };
 
 /**
- * Enhanced error handling utility for expansion operations.
- * Converts various error types to user-friendly messages.
- */
-const handleExpansionError = (error: unknown, context: string): Error => {
-  if (error instanceof Error) {
-    return error;
-  }
-
-  if (typeof error === "string") {
-    return new Error(`${context}: ${error}`);
-  }
-
-  return new Error(`${context}: Unknown error occurred`);
-};
-
-/**
  * Combines existing finality providers with newly selected BSN+FP pairs.
  */
 const combineProviders = (
@@ -135,7 +119,10 @@ export function useStakingExpansionService() {
   const calculateExpansionFeeAmount = useCallback(
     async (formData: StakingExpansionFormData) => {
       if (!validateExpansionFormData(formData)) {
-        throw new Error("Invalid expansion form data provided");
+        throw new ClientError(
+          ERROR_CODES.VALIDATION_ERROR,
+          "Invalid expansion form data provided",
+        );
       }
 
       try {
@@ -163,15 +150,14 @@ export function useStakingExpansionService() {
 
         return feeAmount;
       } catch (error) {
-        const properError = handleExpansionError(
-          error,
+        throw new ClientError(
+          ERROR_CODES.STAKING_EXPANSION_FEE_ERROR,
           "Failed to calculate expansion fee",
+          { cause: error },
         );
-        logger.error(properError);
-        throw properError;
       }
     },
-    [estimateStakingExpansionFee, logger],
+    [estimateStakingExpansionFee],
   );
 
   /**


### PR DESCRIPTION
- shows client error in the UI using modal
- this is useful when we have errors for fee calculation
- before this implementation it was silently using the `logger`, which is not a good UX

UI:
<img width="891" height="780" alt="Снимок экрана 2025-08-15 в 10 22 48" src="https://github.com/user-attachments/assets/11a0907b-f66f-4aac-bd31-29fdc12f88e2" />
