### PR TITLE
feat: show disabled history, remove 0

### DIFF
--- a/src/ui/common/components/Activity/components/ExpansionButton.tsx
+++ b/src/ui/common/components/Activity/components/ExpansionButton.tsx
@@ -44,7 +44,7 @@ export function ExpansionButton({
         </ThemedIcon>
         <div className="flex flex-col w-full items-start">
           <span className="text-sm text-accent-primary">{text}</span>
-          <span className="text-xs">{counter && <span>{counter}</span>}</span>
+          {counter && <span className="text-xs">{counter}</span>}
         </div>
         <MdKeyboardArrowDown
           size={24}

--- a/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
+++ b/src/ui/common/components/Activity/components/StakeExpansionSection.tsx
@@ -103,15 +103,17 @@ export function StakeExpansionSection({
               onClick={handleAddBsnFp}
               disabled={!canExpandDelegation || processing}
             />
-            {expansionHistoryCount > 0 && (
-              <ExpansionButton
-                Icon={iconHistory}
-                text="Expansion History"
-                counter={`${expansionHistoryCount}`}
-                onClick={handleExpansionHistory}
-                disabled={processing}
-              />
-            )}
+            <ExpansionButton
+              Icon={iconHistory}
+              text="Expansion History"
+              counter={
+                expansionHistoryCount > 0
+                  ? `${expansionHistoryCount}`
+                  : undefined
+              }
+              onClick={handleExpansionHistory}
+              disabled={expansionHistoryCount === 0 || processing}
+            />
           </div>
         </AccordionDetails>
       </Accordion>


### PR DESCRIPTION
- after we polish the app, we completely remove the `history` button when there's no expansion history
- but after we had some conversations in Figma, the decision is to `show` this button in `disabled` state
- I removed `0` so it's less distracting

UI:

<img width="787" height="736" alt="Снимок экрана 2025-08-15 в 10 39 03" src="https://github.com/user-attachments/assets/9a073b70-a901-4ff9-b9b6-50173ead3368" />
