### PR TITLE
fix: race condition in the baby staking fee

### DIFF
--- a/src/ui/baby/components/PreviewModal/index.tsx
+++ b/src/ui/baby/components/PreviewModal/index.tsx
@@ -41,12 +41,11 @@ export const PreviewModal = ({
   onSubmit,
   data,
 }: PreviewModalProps) => {
-  // Watch for real-time fee changes from the form
   const currentFeeAmount = useWatch({ name: "feeAmount" });
 
   if (!data) return null;
   const { amount, validator } = data;
-  const feeAmount = currentFeeAmount || data.feeAmount;
+  const feeAmount = currentFeeAmount ?? data.feeAmount;
 
   const babyAmount = babylon.utils.ubbnToBaby(BigInt(amount));
   const babyFeeAmount = babylon.utils.ubbnToBaby(BigInt(feeAmount));


### PR DESCRIPTION
Fix bug in BABY staking fees: when the preview modal opens before the staking form finishes calculating the fee, the fee is not displayed in the preview.