### PR TITLE
fix(BABY): show avaiable balance instead of wallet balance

### DIFF
--- a/src/ui/baby/widgets/StakingForm/index.tsx
+++ b/src/ui/baby/widgets/StakingForm/index.tsx
@@ -14,8 +14,14 @@ interface FormFields {
 }
 
 export default function StakingForm() {
-  const { loading, formSchema, balance, babyPrice, calculateFee, showPreview } =
-    useStakingState();
+  const {
+    loading,
+    formSchema,
+    availableBalance,
+    babyPrice,
+    calculateFee,
+    showPreview,
+  } = useStakingState();
 
   const handlePreview = ({
     amount,
@@ -31,7 +37,7 @@ export default function StakingForm() {
       className="flex flex-col gap-2 h-[500px]"
       onSubmit={handlePreview}
     >
-      <AmountField balance={balance} price={babyPrice} />
+      <AmountField balance={availableBalance} price={babyPrice} />
       <ValidatorField />
       <FeeField babyPrice={babyPrice} calculateFee={calculateFee} />
 


### PR DESCRIPTION
Can't show in the screenshot for this fix.
The idea is when we perform a new stake, we should deduce the available balance user can stake in the staking form.
This is to fix the bug for below scenario:
1. User have 50 BABY
2. User stake 30 BABY
3. User stake another 30 BABY again --> This should not happen in the UI. we should show 20 available to stake.