### PR TITLE
fix: sort baby validator by token amount

### DIFF
--- a/src/ui/baby/hooks/services/useValidatorService.ts
+++ b/src/ui/baby/hooks/services/useValidatorService.ts
@@ -20,16 +20,18 @@ export function useValidatorService() {
 
   const validators = useMemo(
     () =>
-      validatorList.map((validator) => ({
-        address: validator.operatorAddress,
-        name: validator.description.moniker,
-        tokens: parseFloat(validator.tokens),
-        votingPower: parseFloat(validator.tokens) / (pool?.bondedTokens ?? 0),
-        commission: parseFloat(validator.commission.commissionRates.rate),
-        unbondingTime: Number(validator.unbondingTime.seconds) * 1000,
-        // apr: 0,
-        // logoUrl: "",
-      })),
+      validatorList
+        .map((validator) => ({
+          address: validator.operatorAddress,
+          name: validator.description.moniker,
+          tokens: parseFloat(validator.tokens),
+          votingPower: parseFloat(validator.tokens) / (pool?.bondedTokens ?? 0),
+          commission: parseFloat(validator.commission.commissionRates.rate),
+          unbondingTime: Number(validator.unbondingTime.seconds) * 1000,
+          // apr: 0,
+          // logoUrl: "",
+        }))
+        .sort((a, b) => b.tokens - a.tokens),
     [validatorList, pool?.bondedTokens],
   );
 


### PR DESCRIPTION
<img width="530" height="488" alt="image" src="https://github.com/user-attachments/assets/88fbe5ed-78b5-4f1c-8798-7d0bd3f7aa3a" />


Sort by token amount will result in sort by voting power