### PR TITLE
fix: network env should come from a single source

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @0xDazzer @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+* @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov

--- a/src/infrastructure/babylon.ts
+++ b/src/infrastructure/babylon.ts
@@ -1,12 +1,13 @@
 import { createLCDClient, txs, utils } from "@babylonlabs-io/babylon-proto-ts";
 
-import config from "./config";
+import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
 
 let clientInstance: Awaited<ReturnType<typeof createLCDClient>> | null = null;
 
 export const getBabylonClient = async () => {
   if (!clientInstance) {
-    clientInstance = await createLCDClient({ url: config.babylon.lcdUrl });
+    const networkConfig = getNetworkConfigBBN();
+    clientInstance = await createLCDClient({ url: networkConfig.lcdUrl });
   }
   return clientInstance;
 };

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -1,3 +1,5 @@
+// TODO: Below config is not in use yet.
+// This is a placeholder for future code refactoring purposes.
 export default {
   api: {
     baseUrl:

--- a/src/ui/baby/widgets/ValidatorField/index.tsx
+++ b/src/ui/baby/widgets/ValidatorField/index.tsx
@@ -59,7 +59,7 @@ export function ValidatorField() {
   return (
     <>
       <ListSubsection
-        title="Selected Validator"
+        title="Select Validator"
         max={1}
         items={selectedValidators}
         renderItem={(item) => <ValidatorItem name={item.name} />}


### PR DESCRIPTION
1. Update default reviewer list
2. Fix typo on select validator
3. remove the use of network config from new architectural files. We should adopt it when it is ready across entire repo