### PR TITLE
fix(BABY): effectiveAmount should >= unbonding amount

### DIFF
--- a/src/ui/baby/hooks/services/useDelegationService.ts
+++ b/src/ui/baby/hooks/services/useDelegationService.ts
@@ -117,9 +117,9 @@ export function useDelegationService() {
             const unbondingAmount =
               unbondingInfoByValidator[validatorAddress].amount;
             effectiveAmount =
-              effectiveAmount > unbondingAmount
+              effectiveAmount >= unbondingAmount
                 ? effectiveAmount - unbondingAmount
-                : effectiveAmount;
+                : 0n;
             status = "unbonding";
           }
 


### PR DESCRIPTION
When a user initiates an unbonding for an amount that is equal to their staked
amount (apiAmount), the effectiveAmount is incorrectly set to apiAmount instead
of 0n. This occurs because the ternary condition only checks if apiAmount >
unbondingAmount, failing to handle the equality case correctly.

This PR fix this issue