### PR TITLE
fix: add finality provider validation

### DIFF
--- a/src/ui/common/state/MultistakingState.tsx
+++ b/src/ui/common/state/MultistakingState.tsx
@@ -85,7 +85,8 @@ export function MultistakingState({ children }: PropsWithChildren) {
             .test(
               "containsBbnProvider",
               "Add Babylon Finality Provider",
-              (values) => values?.includes(BBN_CHAIN_ID),
+              (_, context) =>
+                Object.keys(context.originalValue || {}).includes(BBN_CHAIN_ID),
             ),
         },
         {

--- a/tests/state/MultistakingState.test.ts
+++ b/tests/state/MultistakingState.test.ts
@@ -1,0 +1,51 @@
+import { array, object, string } from "yup";
+
+import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
+
+const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
+
+describe("MultistakingState validation", () => {
+  it("should validate finalityProviders correctly using context.originalValue", async () => {
+    const schema = object({
+      finalityProviders: array()
+        .of(string())
+        .transform((value) => Object.values(value))
+        .required("Add Finality Provider")
+        .min(1, "Add Finality Provider")
+        .test(
+          "containsBbnProvider",
+          "Add Babylon Finality Provider",
+          (_, context) =>
+            Object.keys(context.originalValue || {}).includes(BBN_CHAIN_ID),
+        ),
+    });
+
+    // Valid case: Record with BBN_CHAIN_ID as key
+    const validData = {
+      finalityProviders: {
+        [BBN_CHAIN_ID]: "babylon-provider-123",
+        bitcoin: "bitcoin-provider-456",
+      },
+    };
+    await expect(schema.validate(validData)).resolves.toBeDefined();
+
+    // Invalid case: Record without BBN_CHAIN_ID as key
+    const invalidData = {
+      finalityProviders: {
+        bitcoin: "bitcoin-provider-456",
+        "other-chain": "other-provider-789",
+      },
+    };
+    await expect(schema.validate(invalidData)).rejects.toThrow(
+      "Add Babylon Finality Provider",
+    );
+
+    // Invalid case: Empty object
+    const emptyData = {
+      finalityProviders: {},
+    };
+    await expect(schema.validate(emptyData)).rejects.toThrow(
+      "Add Finality Provider",
+    );
+  });
+});


### PR DESCRIPTION
This pull request makes a small adjustment to the validation logic in the `MultistakingState` component to correctly check for the presence of the Babylon Finality Provider.

* Updated the validation in `MultistakingState` to check if `BBN_CHAIN_ID` is a key in the original value object, rather than checking if it's included in an array.