### PR TITLE
fix: expansion activity scrollable fp

### DIFF
--- a/src/ui/common/components/ActivityCard/components/ActivityCardDetailsSection.tsx
+++ b/src/ui/common/components/ActivityCard/components/ActivityCardDetailsSection.tsx
@@ -26,7 +26,7 @@ function DetailRow({ label, value }: DetailRowProps) {
       <span className="text-xs sm:text-sm text-accent-primary flex-shrink-0">
         {label}
       </span>
-      <span className="text-xs sm:text-sm text-accent-primary font-medium text-right min-w-0">
+      <span className="text-xs sm:text-sm text-accent-primary font-medium text-right min-w-0 truncate overflow-hidden text-ellipsis">
         {value}
       </span>
     </div>


### PR DESCRIPTION
- fixes the `activity` card scrollable `fp` section


Before: 
<img width="799" height="416" alt="image" src="https://github.com/user-attachments/assets/100e8443-9e8b-472a-869e-65bac057635e" />

After: 
<img width="787" height="404" alt="Screenshot_2025-08-27_15-24-10" src="https://github.com/user-attachments/assets/fbb31674-3dc8-4a2c-97f9-ba22c5f0e0a0" />


Closes https://github.com/babylonlabs-io/simple-staking/issues/1473