### PR TITLE
feat: add table view for finality provider selection (#1402)

### DIFF
--- a/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviders.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviders.tsx
@@ -1,3 +1,8 @@
+import { IconButton } from "@babylonlabs-io/core-ui";
+import { useState } from "react";
+import { IoGridSharp } from "react-icons/io5";
+import { MdTableRows } from "react-icons/md";
+
 import { FinalityProviderFilter } from "@/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter";
 import { FinalityProviderSearch } from "@/ui/common/components/Multistaking/FinalityProviders/FinalityProviderSearch";
 import { FinalityProviderTable } from "@/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable";
@@ -8,6 +13,8 @@ interface Props {
 }
 
 export const FinalityProviders = ({ selectedFP, onChange }: Props) => {
+  const [layout, setLayout] = useState<"grid" | "list">("grid");
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col md:flex-row gap-4">
@@ -17,9 +24,26 @@ export const FinalityProviders = ({ selectedFP, onChange }: Props) => {
         <div className="w-full md:w-[200px]">
           <FinalityProviderFilter />
         </div>
+        <div className="flex items-center gap-2 text-secondary-strokeDark/50">
+          <IconButton
+            onClick={() => setLayout(layout === "grid" ? "list" : "grid")}
+          >
+            <div className="text-accent-primary">
+              {layout === "grid" ? (
+                <MdTableRows size={24} />
+              ) : (
+                <IoGridSharp size={20} />
+              )}
+            </div>
+          </IconButton>
+        </div>
       </div>
 
-      <FinalityProviderTable selectedFP={selectedFP} onSelectRow={onChange} />
+      <FinalityProviderTable
+        selectedFP={selectedFP}
+        onSelectRow={onChange}
+        layout={layout}
+      />
     </div>
   );
 };

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
@@ -18,6 +18,7 @@ export const FinalityProviderFilter = () => {
       value={filter.search ? "" : filter.status}
       disabled={Boolean(filter.search)}
       renderSelectedOption={(option) => `Showing ${option.label}`}
+      className="h-10"
     />
   );
 };

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderSearch.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderSearch.tsx
@@ -38,6 +38,7 @@ export const FinalityProviderSearch = () => {
       suffix={searchSuffix}
       value={filter.search}
       onChange={onSearchChange}
+      className="h-[22px]"
     />
   );
 };

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
@@ -207,7 +207,7 @@ export const FinalityProviderTable = ({
                     {row.commission} %
                   </div>
                 ),
-                sorter: (a, b) => a.commission - b.commission,
+                sorter: (a, b) => parseFloat(a.commission) - parseFloat(b.commission),
               },
             ]}
             isRowSelectable={(row) => row.isSelectable}

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
@@ -197,7 +197,7 @@ export const FinalityProviderTable = ({
                     {row.totalDelegation} {coinSymbol}
                   </div>
                 ),
-                sorter: (a, b) => parseFloat(a.totalDelegation) - parseFloat(b.totalDelegation),
+                sorter: (a, b) => a.totalDelegation - b.totalDelegation,
               },
               {
                 key: "commission",
@@ -207,7 +207,7 @@ export const FinalityProviderTable = ({
                     {row.commission} %
                   </div>
                 ),
-                sorter: (a, b) => parseFloat(a.commission) - parseFloat(b.commission),
+                sorter: (a, b) => a.commission - b.commission,
               },
             ]}
             isRowSelectable={(row) => row.isSelectable}

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderTable.tsx
@@ -197,7 +197,7 @@ export const FinalityProviderTable = ({
                     {row.totalDelegation} {coinSymbol}
                   </div>
                 ),
-                sorter: (a, b) => a.totalDelegation - b.totalDelegation,
+                sorter: (a, b) => parseFloat(a.totalDelegation) - parseFloat(b.totalDelegation),
               },
               {
                 key: "commission",


### PR DESCRIPTION
To keep the design consistent, I've used the default "selected" indicator. I can use the plus icon like in the Figma if necessary.

https://github.com/user-attachments/assets/966b333a-dc5a-43eb-b816-339ba13a1358