### PR TITLE
feat: show bsns instead of fps if phase 3 enabled

### DIFF
--- a/src/ui/common/components/Stats/Stats.tsx
+++ b/src/ui/common/components/Stats/Stats.tsx
@@ -3,9 +3,11 @@ import { memo } from "react";
 
 import { Section } from "@/ui/common/components/Section/Section";
 import { getNetworkConfigBTC } from "@/ui/common/config/network/btc";
+import { useBsn } from "@/ui/common/hooks/client/api/useBsn";
 import { usePrice } from "@/ui/common/hooks/client/api/usePrices";
 import { useSystemStats } from "@/ui/common/hooks/client/api/useSystemStats";
 import { satoshiToBtc } from "@/ui/common/utils/btc";
+import FeatureFlagService from "@/ui/common/utils/FeatureFlagService";
 import { formatBTCTvl } from "@/ui/common/utils/formatBTCTvl";
 
 import { StatItem } from "./StatItem";
@@ -28,6 +30,9 @@ export const Stats = memo(() => {
     isLoading,
   } = useSystemStats();
   const usdRate = usePrice(coinSymbol);
+  const { data: bsns = [], isLoading: isBsnLoading } = useBsn({
+    enabled: FeatureFlagService.IsPhase3Enabled,
+  });
 
   return (
     <Section title="Babylon Bitcoin Staking Stats">
@@ -49,11 +54,19 @@ export const Stats = memo(() => {
           value={`${formatter.format(stakingAPR ? stakingAPR * 100 : 0)}%`}
         />
 
-        <StatItem
-          loading={isLoading}
-          title="Finality Providers"
-          value={`${formatter.format(activeFPs)} Active (${formatter.format(totalFPs)} Total)`}
-        />
+        {FeatureFlagService.IsPhase3Enabled ? (
+          <StatItem
+            loading={isLoading || isBsnLoading}
+            title="BSNs"
+            value={`${formatter.format(bsns.length)}`}
+          />
+        ) : (
+          <StatItem
+            loading={isLoading}
+            title="Finality Providers"
+            value={`${formatter.format(activeFPs)} Active (${formatter.format(totalFPs)} Total)`}
+          />
+        )}
       </List>
     </Section>
   );


### PR DESCRIPTION
If IsPhase3Enabled feature flag is true:
<img width="277" height="97" alt="image" src="https://github.com/user-attachments/assets/b7f3a12f-0bcb-4dff-bc89-7547ac4c7e92" />
