### PR TITLE
stop clearing pending operations on epoch change to prevent disappearing unbond state

### DIFF
--- a/src/ui/baby/hooks/api/useEpochPolling.ts
+++ b/src/ui/baby/hooks/api/useEpochPolling.ts
@@ -4,18 +4,12 @@ import { useEffect, useRef } from "react";
 import babylon from "@/infrastructure/babylon";
 import { ONE_MINUTE } from "@/ui/common/constants";
 
-import { usePendingOperationsService } from "../services/usePendingOperationsService";
-
 import { BABY_DELEGATIONS_KEY } from "./useDelegations";
 import { BABY_UNBONDING_DELEGATIONS_KEY } from "./useUnbondingDelegations";
 
 export function useEpochPolling(address?: string) {
   const queryClient = useQueryClient();
   const previousEpochRef = useRef<number | undefined>(undefined);
-  const { cleanupAllPendingOperationsFromStorage } =
-    usePendingOperationsService();
-  const cleanupRef = useRef(cleanupAllPendingOperationsFromStorage);
-  cleanupRef.current = cleanupAllPendingOperationsFromStorage;
 
   useEffect(() => {
     if (!address) return;
@@ -33,8 +27,6 @@ export function useEpochPolling(address?: string) {
         }
 
         if (!cancelled && currentEpoch !== previousEpochRef.current) {
-          cleanupRef.current?.();
-
           queryClient.invalidateQueries({
             queryKey: [BABY_DELEGATIONS_KEY],
             refetchType: "active",


### PR DESCRIPTION
Do not clear pending operations on epoch change.
Prevents pending entries disappearing after one minute.