### PR TITLE
fix: prevent error modal for non critical errors

### DIFF
--- a/src/ui/common/hooks/client/api/useOrdinals.ts
+++ b/src/ui/common/hooks/client/api/useOrdinals.ts
@@ -3,7 +3,6 @@ import { InscriptionIdentifier } from "@babylonlabs-io/wallet-connector";
 
 import { postVerifyUtxoOrdinals } from "@/ui/common/api/postFilterOrdinals";
 import { ONE_MINUTE } from "@/ui/common/constants";
-import { useError } from "@/ui/common/context/Error/ErrorProvider";
 import { useBTCWallet } from "@/ui/common/context/wallet/BTCWalletProvider";
 import { ClientError, ERROR_CODES } from "@/ui/common/errors";
 import { useClientQuery } from "@/ui/common/hooks/client/useClient";
@@ -19,7 +18,6 @@ export function useOrdinals(
   { enabled = true }: { enabled?: boolean } = {},
 ) {
   const { getInscriptions, address, publicKeyNoCoord } = useBTCWallet();
-  const { handleError } = useError();
   const logger = useLogger();
 
   const fetchOrdinals = async (): Promise<InscriptionIdentifier[]> => {
@@ -50,14 +48,11 @@ export function useOrdinals(
           cause: error as Error,
         },
       );
-      handleError({
-        error: clientError,
-        displayOptions: {
-          retryAction: () => fetchOrdinals(),
-        },
-        metadata: {
-          userPublicKey: publicKeyNoCoord,
-          btcAddress: address,
+      logger.error(clientError, {
+        data: {
+          userPublicKey: publicKeyNoCoord || "",
+          btcAddress: address || "",
+          source: "ORDINALS",
         },
       });
       // App should work without ordinals

--- a/src/ui/common/hooks/client/api/useSystemStats.ts
+++ b/src/ui/common/hooks/client/api/useSystemStats.ts
@@ -2,11 +2,11 @@ import { getSystemStats } from "@/ui/common/api/getSystemStats";
 import { ONE_MINUTE } from "@/ui/common/constants";
 import { useClientQuery } from "@/ui/common/hooks/client/useClient";
 
-export const BTC_TIP_HEIGHT_KEY = "API_STATS";
+export const SYSTEM_STATS_KEY = "API_STATS";
 
 export function useSystemStats({ enabled = true }: { enabled?: boolean } = {}) {
   return useClientQuery({
-    queryKey: ["API_STATS"],
+    queryKey: [SYSTEM_STATS_KEY],
     queryFn: () => getSystemStats(),
     refetchInterval: ONE_MINUTE,
     enabled,

--- a/src/ui/common/hooks/client/useClient.ts
+++ b/src/ui/common/hooks/client/useClient.ts
@@ -60,6 +60,12 @@ export function useClientQuery<
     ...options,
   });
 
+  const rootKeyString = String(
+    (Array.isArray(options.queryKey)
+      ? options.queryKey[0]
+      : options.queryKey) ?? "",
+  ).toUpperCase();
+
   useEffect(() => {
     if (data.isError) {
       const error = data.error as Error;
@@ -70,11 +76,8 @@ export function useClientQuery<
         return;
       }
 
-      const rootKey = Array.isArray(options.queryKey)
-        ? options.queryKey[0]
-        : options.queryKey;
       const isNonCriticalError = ["API_STATS", "PRICES", "ORDINALS"].includes(
-        String(rootKey ?? "").toUpperCase(),
+        rootKeyString,
       );
 
       const clientError = new ClientError(
@@ -98,7 +101,7 @@ export function useClientQuery<
     data.isError,
     data.refetch,
     logger,
-    options.queryKey,
+    rootKeyString,
   ]);
 
   return data;

--- a/src/ui/common/hooks/client/useClient.ts
+++ b/src/ui/common/hooks/client/useClient.ts
@@ -18,6 +18,9 @@ import {
 } from "@/ui/common/constants";
 import { useError } from "@/ui/common/context/Error/ErrorProvider";
 import { ClientError, ERROR_CODES } from "@/ui/common/errors";
+import { ORDINAL_KEY } from "@/ui/common/hooks/client/api/useOrdinals";
+import { PRICES_KEY } from "@/ui/common/hooks/client/api/usePrices";
+import { SYSTEM_STATS_KEY } from "@/ui/common/hooks/client/api/useSystemStats";
 import { useLogger } from "@/ui/common/hooks/useLogger";
 
 export function useClientQuery<
@@ -76,9 +79,11 @@ export function useClientQuery<
         return;
       }
 
-      const isNonCriticalError = ["API_STATS", "PRICES", "ORDINALS"].includes(
-        rootKeyString,
-      );
+      const isNonCriticalError = [
+        SYSTEM_STATS_KEY,
+        PRICES_KEY,
+        ORDINAL_KEY,
+      ].includes(rootKeyString);
 
       const clientError = new ClientError(
         ERROR_CODES.EXTERNAL_SERVICE_UNAVAILABLE,

--- a/src/ui/common/hooks/client/useClient.ts
+++ b/src/ui/common/hooks/client/useClient.ts
@@ -70,6 +70,13 @@ export function useClientQuery<
         return;
       }
 
+      const rootKey = Array.isArray(options.queryKey)
+        ? options.queryKey[0]
+        : options.queryKey;
+      const isNonCriticalError = ["API_STATS", "PRICES", "ORDINALS"].includes(
+        String(rootKey ?? "").toUpperCase(),
+      );
+
       const clientError = new ClientError(
         ERROR_CODES.EXTERNAL_SERVICE_UNAVAILABLE,
         "Error fetching data from the API",
@@ -81,10 +88,18 @@ export function useClientQuery<
         error: clientError,
         displayOptions: {
           retryAction: data.refetch,
+          showModal: !isNonCriticalError,
         },
       });
     }
-  }, [handleError, data.error, data.isError, data.refetch, logger]);
+  }, [
+    handleError,
+    data.error,
+    data.isError,
+    data.refetch,
+    logger,
+    options.queryKey,
+  ]);
 
   return data;
 }


### PR DESCRIPTION
- Since `useOrdinals` is not throwing, it's logging the error manually.
- Checking the `queryKey` to understand if an error is critical in `useClient.ts`

resolves #1022