### PR TITLE
feat: bsn fp allowlist

### DIFF
--- a/src/ui/common/api/getBsn.ts
+++ b/src/ui/common/api/getBsn.ts
@@ -11,41 +11,44 @@ export const BSN_TYPE_ROLLUP: BsnType = "ROLLUP";
 const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
 
 // BSN Configuration for different types and behaviors
+export interface BsnFilterOption {
+  value: string;
+  label: string;
+}
+
 export interface BsnConfig {
   modalTitle: string;
-  filterLabels: {
-    primary: string;
-    secondary: string;
-  };
-  fpFilterBehavior: "active-inactive" | "allowlist-based";
+  filterOptions: BsnFilterOption[];
+  fpFilterBehavior: "status-based" | "allowlist-based";
 }
 
 export const BSN_CONFIGS: Record<string, BsnConfig> = {
   // Babylon Genesis
   [BBN_CHAIN_ID]: {
     modalTitle: "Select Babylon Genesis Finality Provider",
-    filterLabels: {
-      primary: "Active",
-      secondary: "Inactive",
-    },
-    fpFilterBehavior: "active-inactive",
+    filterOptions: [
+      { value: "active", label: "Active" },
+      { value: "inactive", label: "Inactive" },
+      { value: "jailed", label: "Jailed" },
+      { value: "slashed", label: "Slashed" },
+    ],
+    fpFilterBehavior: "status-based",
   },
-  // Cosmos BSN config
   COSMOS: {
     modalTitle: "Select Cosmos Finality Provider",
-    filterLabels: {
-      primary: "Active",
-      secondary: "Inactive",
-    },
-    fpFilterBehavior: "active-inactive",
+    filterOptions: [
+      { value: "active", label: "Active" },
+      { value: "inactive", label: "Inactive" },
+    ],
+    fpFilterBehavior: "status-based",
   },
   // Roll-up BSN config
   ROLLUP: {
     modalTitle: "Select Roll Up Finality Provider",
-    filterLabels: {
-      primary: "Allow listed",
-      secondary: "Non-Allow listed",
-    },
+    filterOptions: [
+      { value: "active", label: "Allowlisted" },
+      { value: "inactive", label: "Not Allowlisted" },
+    ],
     fpFilterBehavior: "allowlist-based",
   },
 };
@@ -54,7 +57,7 @@ export const BSN_CONFIGS: Record<string, BsnConfig> = {
  * Get BSN configuration based on BSN object
  */
 export const getBsnConfig = (bsn?: Bsn): BsnConfig => {
-  if (!bsn) return BSN_CONFIGS.COSMOS;
+  if (!bsn) return BSN_CONFIGS[BBN_CHAIN_ID];
 
   // Check if it's Babylon Genesis first
   if (bsn.id === BBN_CHAIN_ID) {
@@ -62,7 +65,7 @@ export const getBsnConfig = (bsn?: Bsn): BsnConfig => {
   }
 
   // Use type-based config
-  return BSN_CONFIGS[bsn.type] || BSN_CONFIGS.COSMOS;
+  return BSN_CONFIGS[bsn.type] || BSN_CONFIGS[BBN_CHAIN_ID];
 };
 
 interface BsnAPI {

--- a/src/ui/common/api/getBsn.ts
+++ b/src/ui/common/api/getBsn.ts
@@ -1,13 +1,77 @@
-import { Bsn } from "../types/bsn";
+import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
+
+import { Bsn, BsnType } from "../types/bsn";
 import { getBsnLogoUrl } from "../utils/bsnLogo";
 
 import { apiWrapper } from "./apiWrapper";
+
+export const BSN_TYPE_COSMOS: BsnType = "COSMOS";
+export const BSN_TYPE_ROLLUP: BsnType = "ROLLUP";
+
+const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
+
+// BSN Configuration for different types and behaviors
+export interface BsnConfig {
+  modalTitle: string;
+  filterLabels: {
+    primary: string;
+    secondary: string;
+  };
+  fpFilterBehavior: "active-inactive" | "allowlist-based";
+}
+
+export const BSN_CONFIGS: Record<string, BsnConfig> = {
+  // Babylon Genesis
+  [BBN_CHAIN_ID]: {
+    modalTitle: "Select Babylon Genesis Finality Provider",
+    filterLabels: {
+      primary: "Active",
+      secondary: "Inactive",
+    },
+    fpFilterBehavior: "active-inactive",
+  },
+  // Cosmos BSN config
+  COSMOS: {
+    modalTitle: "Select Cosmos Finality Provider",
+    filterLabels: {
+      primary: "Active",
+      secondary: "Inactive",
+    },
+    fpFilterBehavior: "active-inactive",
+  },
+  // Roll-up BSN config
+  ROLLUP: {
+    modalTitle: "Select Roll Up Finality Provider",
+    filterLabels: {
+      primary: "Allow listed",
+      secondary: "Non-Allow listed",
+    },
+    fpFilterBehavior: "allowlist-based",
+  },
+};
+
+/**
+ * Get BSN configuration based on BSN object
+ */
+export const getBsnConfig = (bsn?: Bsn): BsnConfig => {
+  if (!bsn) return BSN_CONFIGS.COSMOS;
+
+  // Check if it's Babylon Genesis first
+  if (bsn.id === BBN_CHAIN_ID) {
+    return BSN_CONFIGS[BBN_CHAIN_ID];
+  }
+
+  // Use type-based config
+  return BSN_CONFIGS[bsn.type] || BSN_CONFIGS.COSMOS;
+};
 
 interface BsnAPI {
   id: string;
   name: string;
   description: string;
   active_tvl: number;
+  type: BsnType;
+  allowlist?: string[]; // BTC FP pubkeys (hex)
 }
 
 interface BsnDataResponse {
@@ -20,7 +84,15 @@ const createBSN = (bsn: BsnAPI): Bsn => ({
   description: bsn.description,
   activeTvl: bsn.active_tvl,
   logoUrl: getBsnLogoUrl(bsn.id),
+  type: bsn.type,
+  allowlist: bsn.allowlist,
 });
+
+/**
+ * Determines if a BSN is Babylon Genesis
+ */
+export const isBabylonGenesisBsn = (bsn: Bsn): boolean =>
+  bsn.id === BBN_CHAIN_ID;
 
 export const getBSNs = async (): Promise<Bsn[]> => {
   const response = await apiWrapper<BsnDataResponse>(

--- a/src/ui/common/api/getBsn.ts
+++ b/src/ui/common/api/getBsn.ts
@@ -1,74 +1,11 @@
-import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
-
-import { Bsn, BsnType } from "../types/bsn";
-import { getBsnLogoUrl } from "../utils/bsnLogo";
+import { BsnType } from "../types/bsn";
 
 import { apiWrapper } from "./apiWrapper";
 
 export const BSN_TYPE_COSMOS: BsnType = "COSMOS";
 export const BSN_TYPE_ROLLUP: BsnType = "ROLLUP";
 
-const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
-
-// BSN Configuration for different types and behaviors
-export interface BsnFilterOption {
-  value: string;
-  label: string;
-}
-
-export interface BsnConfig {
-  modalTitle: string;
-  filterOptions: BsnFilterOption[];
-  fpFilterBehavior: "status-based" | "allowlist-based";
-}
-
-export const BSN_CONFIGS: Record<string, BsnConfig> = {
-  // Babylon Genesis
-  [BBN_CHAIN_ID]: {
-    modalTitle: "Select Babylon Genesis Finality Provider",
-    filterOptions: [
-      { value: "active", label: "Active" },
-      { value: "inactive", label: "Inactive" },
-      { value: "jailed", label: "Jailed" },
-      { value: "slashed", label: "Slashed" },
-    ],
-    fpFilterBehavior: "status-based",
-  },
-  COSMOS: {
-    modalTitle: "Select Cosmos Finality Provider",
-    filterOptions: [
-      { value: "active", label: "Active" },
-      { value: "inactive", label: "Inactive" },
-    ],
-    fpFilterBehavior: "status-based",
-  },
-  // Roll-up BSN config
-  ROLLUP: {
-    modalTitle: "Select Roll Up Finality Provider",
-    filterOptions: [
-      { value: "active", label: "Allowlisted" },
-      { value: "inactive", label: "Not Allowlisted" },
-    ],
-    fpFilterBehavior: "allowlist-based",
-  },
-};
-
-/**
- * Get BSN configuration based on BSN object
- */
-export const getBsnConfig = (bsn?: Bsn): BsnConfig => {
-  if (!bsn) return BSN_CONFIGS[BBN_CHAIN_ID];
-
-  // Check if it's Babylon Genesis first
-  if (bsn.id === BBN_CHAIN_ID) {
-    return BSN_CONFIGS[BBN_CHAIN_ID];
-  }
-
-  // Use type-based config
-  return BSN_CONFIGS[bsn.type] || BSN_CONFIGS[BBN_CHAIN_ID];
-};
-
-interface BsnAPI {
+export interface BsnAPI {
   id: string;
   name: string;
   description: string;
@@ -81,29 +18,12 @@ interface BsnDataResponse {
   data: BsnAPI[];
 }
 
-const createBSN = (bsn: BsnAPI): Bsn => ({
-  id: bsn.id,
-  name: bsn.name,
-  description: bsn.description,
-  activeTvl: bsn.active_tvl,
-  logoUrl: getBsnLogoUrl(bsn.id),
-  type: bsn.type,
-  allowlist: bsn.allowlist,
-});
-
-/**
- * Determines if a BSN is Babylon Genesis
- */
-export const isBabylonGenesisBsn = (bsn: Bsn): boolean =>
-  bsn.id === BBN_CHAIN_ID;
-
-export const getBSNs = async (): Promise<Bsn[]> => {
+export const getBsnAPI = async (): Promise<BsnAPI[]> => {
   const response = await apiWrapper<BsnDataResponse>(
     "GET",
     "/v2/bsn",
     "Error getting BSN list",
   );
 
-  const { data } = response.data;
-  return data.map(createBSN);
+  return response.data.data;
 };

--- a/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal.tsx
@@ -4,10 +4,12 @@ import {
   DialogFooter,
   DialogHeader,
 } from "@babylonlabs-io/core-ui";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { getBsnConfig } from "@/ui/common/api/getBsn";
 import { ResponsiveDialog } from "@/ui/common/components/Modals/ResponsiveDialog";
 import { FinalityProviders } from "@/ui/common/components/Multistaking/FinalityProviderField/FinalityProviders";
+import { useFinalityProviderBsnState } from "@/ui/common/state/FinalityProviderBsnState";
 
 interface Props {
   open: boolean;
@@ -27,6 +29,9 @@ export const FinalityProviderModal = ({
   onBack,
 }: Props) => {
   const [selectedFP, setSelectedFp] = useState(defaultFinalityProvider);
+  const { selectedBsn } = useFinalityProviderBsnState();
+
+  const bsnConfig = useMemo(() => getBsnConfig(selectedBsn), [selectedBsn]);
 
   const handleClose = () => {
     onClose();
@@ -36,7 +41,7 @@ export const FinalityProviderModal = ({
   return (
     <ResponsiveDialog open={open} onClose={handleClose} className="w-[52rem]">
       <DialogHeader
-        title="Select Finality Provider"
+        title={bsnConfig.modalTitle}
         onClose={handleClose}
         className="text-accent-primary"
       />

--- a/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviderField/FinalityProviderModal.tsx
@@ -4,9 +4,8 @@ import {
   DialogFooter,
   DialogHeader,
 } from "@babylonlabs-io/core-ui";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
-import { getBsnConfig } from "@/ui/common/api/getBsn";
 import { ResponsiveDialog } from "@/ui/common/components/Modals/ResponsiveDialog";
 import { FinalityProviders } from "@/ui/common/components/Multistaking/FinalityProviderField/FinalityProviders";
 import { useFinalityProviderBsnState } from "@/ui/common/state/FinalityProviderBsnState";
@@ -29,9 +28,7 @@ export const FinalityProviderModal = ({
   onBack,
 }: Props) => {
   const [selectedFP, setSelectedFp] = useState(defaultFinalityProvider);
-  const { selectedBsn } = useFinalityProviderBsnState();
-
-  const bsnConfig = useMemo(() => getBsnConfig(selectedBsn), [selectedBsn]);
+  const { modalTitle } = useFinalityProviderBsnState();
 
   const handleClose = () => {
     onClose();
@@ -41,7 +38,7 @@ export const FinalityProviderModal = ({
   return (
     <ResponsiveDialog open={open} onClose={handleClose} className="w-[52rem]">
       <DialogHeader
-        title={bsnConfig.modalTitle}
+        title={modalTitle}
         onClose={handleClose}
         className="text-accent-primary"
       />

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
@@ -10,11 +10,8 @@ export const FinalityProviderFilter = () => {
   const bsnConfig = useMemo(() => getBsnConfig(selectedBsn), [selectedBsn]);
 
   const options = useMemo(
-    () => [
-      { value: "active", label: bsnConfig.filterLabels.primary },
-      { value: "inactive", label: bsnConfig.filterLabels.secondary },
-    ],
-    [bsnConfig.filterLabels],
+    () => bsnConfig.filterOptions,
+    [bsnConfig.filterOptions],
   );
 
   return (

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
@@ -1,22 +1,29 @@
 import { Select } from "@babylonlabs-io/core-ui";
+import { useMemo } from "react";
 
+import { getBsnConfig } from "@/ui/common/api/getBsn";
 import { useFinalityProviderBsnState } from "@/ui/common/state/FinalityProviderBsnState";
 
-const options = [
-  { value: "active", label: "Active" },
-  { value: "inactive", label: "Inactive" },
-];
-
 export const FinalityProviderFilter = () => {
-  const { filter, handleFilter } = useFinalityProviderBsnState();
+  const { filter, handleFilter, selectedBsn } = useFinalityProviderBsnState();
+
+  const bsnConfig = useMemo(() => getBsnConfig(selectedBsn), [selectedBsn]);
+
+  const options = useMemo(
+    () => [
+      { value: "active", label: bsnConfig.filterLabels.primary },
+      { value: "inactive", label: bsnConfig.filterLabels.secondary },
+    ],
+    [bsnConfig.filterLabels],
+  );
 
   return (
     <Select
       options={options}
-      onSelect={(value) => handleFilter("status", value.toString())}
+      onSelect={(value) => handleFilter("providerStatus", value.toString())}
       placeholder="Select Status"
-      value={filter.search ? "" : filter.status}
-      disabled={Boolean(filter.search)}
+      value={filter.searchTerm ? "" : filter.providerStatus}
+      disabled={Boolean(filter.searchTerm)}
       renderSelectedOption={(option) => `Showing ${option.label}`}
       className="h-10"
     />

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderFilter.tsx
@@ -1,22 +1,13 @@
 import { Select } from "@babylonlabs-io/core-ui";
-import { useMemo } from "react";
 
-import { getBsnConfig } from "@/ui/common/api/getBsn";
 import { useFinalityProviderBsnState } from "@/ui/common/state/FinalityProviderBsnState";
 
 export const FinalityProviderFilter = () => {
-  const { filter, handleFilter, selectedBsn } = useFinalityProviderBsnState();
-
-  const bsnConfig = useMemo(() => getBsnConfig(selectedBsn), [selectedBsn]);
-
-  const options = useMemo(
-    () => bsnConfig.filterOptions,
-    [bsnConfig.filterOptions],
-  );
+  const { filter, handleFilter, filterOptions } = useFinalityProviderBsnState();
 
   return (
     <Select
-      options={options}
+      options={filterOptions}
       onSelect={(value) => handleFilter("providerStatus", value.toString())}
       placeholder="Select Status"
       value={filter.searchTerm ? "" : filter.providerStatus}

--- a/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderSearch.tsx
+++ b/src/ui/common/components/Multistaking/FinalityProviders/FinalityProviderSearch.tsx
@@ -10,16 +10,16 @@ export const FinalityProviderSearch = () => {
 
   const onSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      handleFilter("search", e.target.value);
+      handleFilter("searchTerm", e.target.value);
     },
     [handleFilter],
   );
 
   const onClearSearch = useCallback(() => {
-    handleFilter("search", "");
+    handleFilter("searchTerm", "");
   }, [handleFilter]);
 
-  const searchSuffix = filter.search ? (
+  const searchSuffix = filter.searchTerm ? (
     <button
       onClick={onClearSearch}
       className="opacity-60 hover:opacity-100 transition-opacity"
@@ -36,7 +36,7 @@ export const FinalityProviderSearch = () => {
     <Input
       placeholder="Search by Name or Public Key"
       suffix={searchSuffix}
-      value={filter.search}
+      value={filter.searchTerm}
       onChange={onSearchChange}
       className="h-[22px]"
     />

--- a/src/ui/common/hooks/client/api/useBsn.ts
+++ b/src/ui/common/hooks/client/api/useBsn.ts
@@ -1,6 +1,6 @@
-import { getBSNs } from "@/ui/common/api/getBsn";
 import { ONE_MINUTE } from "@/ui/common/constants";
 import { useClientQuery } from "@/ui/common/hooks/client/useClient";
+import { getBSNs } from "@/ui/common/services/bsnService";
 import { Bsn } from "@/ui/common/types/bsn";
 
 export const BSN_KEY = "BSN";

--- a/src/ui/common/hooks/client/api/useBsn.ts
+++ b/src/ui/common/hooks/client/api/useBsn.ts
@@ -1,9 +1,15 @@
+import { getBsnAPI } from "@/ui/common/api/getBsn";
 import { ONE_MINUTE } from "@/ui/common/constants";
 import { useClientQuery } from "@/ui/common/hooks/client/useClient";
-import { getBSNs } from "@/ui/common/services/bsnService";
+import { createBSN } from "@/ui/common/services/bsnService";
 import { Bsn } from "@/ui/common/types/bsn";
 
 export const BSN_KEY = "BSN";
+
+const getBSNs = async (): Promise<Bsn[]> => {
+  const data = await getBsnAPI();
+  return data.map(createBSN);
+};
 
 export function useBsn({ enabled = true }: { enabled?: boolean } = {}) {
   return useClientQuery<Bsn[]>({

--- a/src/ui/common/services/bsnService.ts
+++ b/src/ui/common/services/bsnService.ts
@@ -1,3 +1,4 @@
+import logger from "@/infrastructure/logger";
 import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
 
 import { getBsnAPI } from "../api/getBsn";
@@ -62,7 +63,19 @@ export const getBsnConfig = (bsn?: Bsn): BsnConfig => {
   }
 
   // Use type-based config
-  return BSN_CONFIGS[bsn.type] || BSN_CONFIGS[BBN_CHAIN_ID];
+  const config = BSN_CONFIGS[bsn.type];
+  if (!config) {
+    logger.error(new Error(`BSN config not found for type: ${bsn.type}`), {
+      tags: { service: "bsnService", function: "getBsnConfig" },
+      data: {
+        bsnType: bsn.type,
+        bsnId: bsn.id,
+        fallback: "Babylon Genesis config",
+      },
+    });
+    return BSN_CONFIGS[BBN_CHAIN_ID];
+  }
+  return config;
 };
 
 /**

--- a/src/ui/common/services/bsnService.ts
+++ b/src/ui/common/services/bsnService.ts
@@ -1,7 +1,6 @@
 import logger from "@/infrastructure/logger";
 import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
 
-import { getBsnAPI } from "../api/getBsn";
 import { Bsn, BsnType } from "../types/bsn";
 import { getBsnLogoUrl } from "../utils/bsnLogo";
 
@@ -15,7 +14,6 @@ export interface BsnFilterOption {
 export interface BsnConfig {
   modalTitle: string;
   filterOptions: BsnFilterOption[];
-  fpFilterBehavior: "status-based" | "allowlist-based";
 }
 
 export const BSN_CONFIGS: Record<string, BsnConfig> = {
@@ -28,7 +26,6 @@ export const BSN_CONFIGS: Record<string, BsnConfig> = {
       { value: "jailed", label: "Jailed" },
       { value: "slashed", label: "Slashed" },
     ],
-    fpFilterBehavior: "status-based",
   },
   COSMOS: {
     modalTitle: "Select Cosmos Finality Provider",
@@ -36,7 +33,6 @@ export const BSN_CONFIGS: Record<string, BsnConfig> = {
       { value: "registered", label: "Registered" },
       { value: "slashed", label: "Slashed" },
     ],
-    fpFilterBehavior: "status-based",
   },
   // Roll-up BSN config
   ROLLUP: {
@@ -47,7 +43,6 @@ export const BSN_CONFIGS: Record<string, BsnConfig> = {
       { value: "slashed", label: "Slashed" },
       { value: "jailed", label: "Jailed" },
     ],
-    fpFilterBehavior: "allowlist-based",
   },
 };
 
@@ -78,12 +73,6 @@ export const getBsnConfig = (bsn?: Bsn): BsnConfig => {
   return config;
 };
 
-/**
- * Determines if a BSN is Babylon Genesis
- */
-export const isBabylonGenesisBsn = (bsn: Bsn): boolean =>
-  bsn.id === BBN_CHAIN_ID;
-
 export const createBSN = (bsn: {
   id: string;
   name: string;
@@ -100,10 +89,3 @@ export const createBSN = (bsn: {
   type: bsn.type,
   allowlist: bsn.allowlist,
 });
-
-/**
- */
-export const getBSNs = async (): Promise<Bsn[]> => {
-  const data = await getBsnAPI();
-  return data.map(createBSN);
-};

--- a/src/ui/common/services/bsnService.ts
+++ b/src/ui/common/services/bsnService.ts
@@ -32,8 +32,8 @@ export const BSN_CONFIGS: Record<string, BsnConfig> = {
   COSMOS: {
     modalTitle: "Select Cosmos Finality Provider",
     filterOptions: [
-      { value: "active", label: "Active" },
-      { value: "inactive", label: "Inactive" },
+      { value: "registered", label: "Registered" },
+      { value: "slashed", label: "Slashed" },
     ],
     fpFilterBehavior: "status-based",
   },
@@ -41,8 +41,10 @@ export const BSN_CONFIGS: Record<string, BsnConfig> = {
   ROLLUP: {
     modalTitle: "Select Roll Up Finality Provider",
     filterOptions: [
-      { value: "active", label: "Allowlisted" },
-      { value: "inactive", label: "Not Allowlisted" },
+      { value: "allowlisted", label: "Allow Listed" },
+      { value: "non-allowlisted", label: "Non-Allow Listed" },
+      { value: "slashed", label: "Slashed" },
+      { value: "jailed", label: "Jailed" },
     ],
     fpFilterBehavior: "allowlist-based",
   },

--- a/src/ui/common/services/bsnService.ts
+++ b/src/ui/common/services/bsnService.ts
@@ -1,0 +1,94 @@
+import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
+
+import { getBsnAPI } from "../api/getBsn";
+import { Bsn, BsnType } from "../types/bsn";
+import { getBsnLogoUrl } from "../utils/bsnLogo";
+
+const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
+
+export interface BsnFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface BsnConfig {
+  modalTitle: string;
+  filterOptions: BsnFilterOption[];
+  fpFilterBehavior: "status-based" | "allowlist-based";
+}
+
+export const BSN_CONFIGS: Record<string, BsnConfig> = {
+  // Babylon Genesis
+  [BBN_CHAIN_ID]: {
+    modalTitle: "Select Babylon Genesis Finality Provider",
+    filterOptions: [
+      { value: "active", label: "Active" },
+      { value: "inactive", label: "Inactive" },
+      { value: "jailed", label: "Jailed" },
+      { value: "slashed", label: "Slashed" },
+    ],
+    fpFilterBehavior: "status-based",
+  },
+  COSMOS: {
+    modalTitle: "Select Cosmos Finality Provider",
+    filterOptions: [
+      { value: "active", label: "Active" },
+      { value: "inactive", label: "Inactive" },
+    ],
+    fpFilterBehavior: "status-based",
+  },
+  // Roll-up BSN config
+  ROLLUP: {
+    modalTitle: "Select Roll Up Finality Provider",
+    filterOptions: [
+      { value: "active", label: "Allowlisted" },
+      { value: "inactive", label: "Not Allowlisted" },
+    ],
+    fpFilterBehavior: "allowlist-based",
+  },
+};
+
+/**
+ * Get BSN configuration based on BSN type
+ */
+export const getBsnConfig = (bsn?: Bsn): BsnConfig => {
+  if (!bsn) return BSN_CONFIGS[BBN_CHAIN_ID];
+
+  // Check if it's Babylon Genesis first
+  if (bsn.id === BBN_CHAIN_ID) {
+    return BSN_CONFIGS[BBN_CHAIN_ID];
+  }
+
+  // Use type-based config
+  return BSN_CONFIGS[bsn.type] || BSN_CONFIGS[BBN_CHAIN_ID];
+};
+
+/**
+ * Determines if a BSN is Babylon Genesis
+ */
+export const isBabylonGenesisBsn = (bsn: Bsn): boolean =>
+  bsn.id === BBN_CHAIN_ID;
+
+export const createBSN = (bsn: {
+  id: string;
+  name: string;
+  description: string;
+  active_tvl: number;
+  type: BsnType;
+  allowlist?: string[];
+}): Bsn => ({
+  id: bsn.id,
+  name: bsn.name,
+  description: bsn.description,
+  activeTvl: bsn.active_tvl,
+  logoUrl: getBsnLogoUrl(bsn.id),
+  type: bsn.type,
+  allowlist: bsn.allowlist,
+});
+
+/**
+ */
+export const getBSNs = async (): Promise<Bsn[]> => {
+  const data = await getBsnAPI();
+  return data.map(createBSN);
+};

--- a/src/ui/common/services/finalityProviderService.ts
+++ b/src/ui/common/services/finalityProviderService.ts
@@ -1,0 +1,164 @@
+import { getNetworkConfigBBN } from "@/ui/common/config/network/bbn";
+import { Bsn } from "@/ui/common/types/bsn";
+import {
+  FinalityProviderState as FinalityProviderStateEnum,
+  type FinalityProvider,
+} from "@/ui/common/types/finalityProviders";
+
+const { chainId: BBN_CHAIN_ID } = getNetworkConfigBBN();
+
+/**
+ * Normalizes hex string by removing 0x prefix and converting to lowercase
+ */
+export const normalizeHex = (hex?: string): string =>
+  (hex ?? "").trim().toLowerCase().replace(/^0x/, "");
+
+// BSN-specific status filters to handle different BSN behaviors
+const BABYLON_STATUS_FILTERS = {
+  active: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.ACTIVE,
+  inactive: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.INACTIVE,
+  jailed: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.JAILED,
+  slashed: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.SLASHED,
+};
+
+const COSMOS_STATUS_FILTERS = {
+  registered: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.INACTIVE,
+  slashed: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.SLASHED,
+};
+
+const BSN_STATUS_FILTERS = {
+  [BBN_CHAIN_ID]: BABYLON_STATUS_FILTERS,
+  COSMOS: COSMOS_STATUS_FILTERS,
+};
+
+/**
+ * Creates allowlist filters for BSN-based filtering
+ */
+export const createAllowlistFilters = (selectedBsn: Bsn | undefined) => {
+  const allowSet = new Set((selectedBsn?.allowlist || []).map(normalizeHex));
+
+  return {
+    allowlisted: (fp: FinalityProvider) => allowSet.has(normalizeHex(fp.btcPk)),
+    "non-allowlisted": (fp: FinalityProvider) =>
+      !allowSet.has(normalizeHex(fp.btcPk)),
+  };
+};
+
+/**
+ * Applies standard status filtering for BABYLON and COSMOS BSNs
+ */
+export const applyStandardStatusFilter = (
+  providers: FinalityProvider[],
+  filterValue: string,
+  bsnKey: string,
+): FinalityProvider[] => {
+  const bsnStatusFilters =
+    BSN_STATUS_FILTERS[bsnKey] || BSN_STATUS_FILTERS[BBN_CHAIN_ID];
+  const statusFilter =
+    bsnStatusFilters[filterValue as keyof typeof bsnStatusFilters];
+  return statusFilter ? providers.filter(statusFilter) : providers;
+};
+
+export interface FinalityProviderFilterState {
+  searchTerm: string;
+  providerStatus:
+    | "active"
+    | "inactive"
+    | "registered"
+    | "allowlisted"
+    | "non-allowlisted"
+    | "slashed"
+    | "jailed"
+    | "";
+  allowlistStatus: "allowlisted" | "non-allowlisted" | "";
+}
+
+/**
+ * Main filtering function that applies BSN-aware filtering logic
+ * Handles both allowlist-based and status-based filtering behaviors
+ */
+export const filterFinalityProvidersByBsn = (
+  providers: FinalityProvider[],
+  filter: FinalityProviderFilterState,
+  selectedBsn: Bsn | undefined,
+  fpFilterBehavior: "status-based" | "allowlist-based",
+): FinalityProvider[] => {
+  let filtered = providers;
+
+  // Apply BSN-aware filtering based on provider status
+  if (filter.providerStatus) {
+    if (fpFilterBehavior === "allowlist-based") {
+      // For rollup BSNs: filter FPs by allowlist status or specific states
+      const allowSet = new Set(
+        (selectedBsn?.allowlist || []).map(normalizeHex),
+      );
+
+      filtered = filtered.filter((fp) => {
+        const isAllowlisted = allowSet.has(normalizeHex(fp.btcPk));
+
+        if (filter.providerStatus === "allowlisted") {
+          return isAllowlisted;
+        } else if (filter.providerStatus === "non-allowlisted") {
+          return !isAllowlisted;
+        } else if (filter.providerStatus === "slashed") {
+          return fp.state === FinalityProviderStateEnum.SLASHED;
+        } else if (filter.providerStatus === "jailed") {
+          return fp.state === FinalityProviderStateEnum.JAILED;
+        }
+        return true;
+      });
+    } else if (fpFilterBehavior === "status-based") {
+      // For status-based BSNs: filter by finality provider state using BSN-specific filters
+      const bsnKey =
+        selectedBsn?.id === BBN_CHAIN_ID
+          ? BBN_CHAIN_ID
+          : selectedBsn?.type || BBN_CHAIN_ID;
+
+      filtered = applyStandardStatusFilter(
+        filtered,
+        filter.providerStatus,
+        bsnKey,
+      );
+    }
+  }
+
+  if (filter.allowlistStatus) {
+    const allowlistFilters = createAllowlistFilters(selectedBsn);
+    const allowlistFilter =
+      allowlistFilters[filter.allowlistStatus as keyof typeof allowlistFilters];
+    if (allowlistFilter) {
+      filtered = filtered.filter(allowlistFilter);
+    }
+  }
+
+  return filtered;
+};
+
+/**
+ * Determines if a finality provider row should be selectable based on BSN rules
+ */
+export const isFinalityProviderRowSelectable = (
+  row: FinalityProvider,
+  selectedBsnId: string | undefined,
+  selectedBsn: Bsn | undefined,
+): boolean => {
+  const statusAllowed =
+    row.state === FinalityProviderStateEnum.ACTIVE ||
+    row.state === FinalityProviderStateEnum.INACTIVE;
+
+  // For selection (not filtering), only restrict based on allowlist for non-Babylon BSNs
+  const allowlistAllowed =
+    !selectedBsnId ||
+    selectedBsnId === BBN_CHAIN_ID ||
+    (selectedBsn?.allowlist || []).some(
+      (allowedPk) => normalizeHex(allowedPk) === normalizeHex(row.btcPk),
+    );
+
+  return statusAllowed && allowlistAllowed;
+};

--- a/src/ui/common/state/FinalityProviderBsnState.tsx
+++ b/src/ui/common/state/FinalityProviderBsnState.tsx
@@ -14,7 +14,7 @@ import {
   filterFinalityProvidersByBsn,
   isFinalityProviderRowSelectable,
   type FinalityProviderFilterState,
-} from "@/ui/common/services/finalityProviderService";
+} from "@/ui/common/services/finalityProviderFilterService";
 import { Bsn } from "@/ui/common/types/bsn";
 import {
   FinalityProviderState as FinalityProviderStateEnum,
@@ -60,7 +60,6 @@ interface FinalityProviderBsnState {
   // BSN Configuration (moved from components to state)
   modalTitle: string;
   filterOptions: BsnFilterOption[];
-  fpFilterBehavior: "status-based" | "allowlist-based";
   // Modal
   stakingModalPage: StakingModalPage;
   setStakingModalPage: (page: StakingModalPage) => void;
@@ -125,7 +124,6 @@ const defaultState: FinalityProviderBsnState = {
     { value: "jailed", label: "Jailed" },
     { value: "slashed", label: "Slashed" },
   ],
-  fpFilterBehavior: "status-based",
   isRowSelectable: () => false,
   handleSort: () => {},
   handleFilter: () => {},
@@ -191,10 +189,6 @@ export function FinalityProviderBsnState({ children }: PropsWithChildren) {
     () => bsnConfig.filterOptions,
     [bsnConfig.filterOptions],
   );
-  const fpFilterBehavior = useMemo(
-    () => bsnConfig.fpFilterBehavior,
-    [bsnConfig.fpFilterBehavior],
-  );
 
   const finalityProviders = useMemo(() => {
     if (!data?.finalityProviders) {
@@ -253,13 +247,8 @@ export function FinalityProviderBsnState({ children }: PropsWithChildren) {
       return filtered;
     }
 
-    return filterFinalityProvidersByBsn(
-      filtered,
-      filter,
-      selectedBsn,
-      fpFilterBehavior,
-    );
-  }, [finalityProviders, filter, selectedBsn, fpFilterBehavior]);
+    return filterFinalityProvidersByBsn(filtered, filter, selectedBsn);
+  }, [finalityProviders, filter, selectedBsn]);
 
   const state = useMemo(
     () => ({
@@ -280,7 +269,6 @@ export function FinalityProviderBsnState({ children }: PropsWithChildren) {
       // BSN Configuration (moved from components to state)
       modalTitle,
       filterOptions,
-      fpFilterBehavior,
       handleSort,
       handleFilter,
       isRowSelectable,
@@ -304,7 +292,6 @@ export function FinalityProviderBsnState({ children }: PropsWithChildren) {
       isError,
       modalTitle,
       filterOptions,
-      fpFilterBehavior,
       handleSort,
       handleFilter,
       isRowSelectable,

--- a/src/ui/common/state/FinalityProviderBsnState.tsx
+++ b/src/ui/common/state/FinalityProviderBsnState.tsx
@@ -84,7 +84,11 @@ const STATUS_FILTERS = {
   active: (fp: FinalityProvider) =>
     fp.state === FinalityProviderStateEnum.ACTIVE,
   inactive: (fp: FinalityProvider) =>
-    fp.state !== FinalityProviderStateEnum.ACTIVE,
+    fp.state === FinalityProviderStateEnum.INACTIVE,
+  jailed: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.JAILED,
+  slashed: (fp: FinalityProvider) =>
+    fp.state === FinalityProviderStateEnum.SLASHED,
 };
 
 const createAllowlistFilters = (selectedBsn: Bsn | undefined) => {
@@ -122,8 +126,8 @@ const filterFinalityProvidersByBsn = (
           return !isAllowlisted;
         }
       });
-    } else {
-      // For cosmos/babylon BSNs: filter by active/inactive status
+    } else if (bsnConfig.fpFilterBehavior === "status-based") {
+      // For status-based BSNs: filter by finality provider state (active/inactive/jailed/slashed)
       const statusFilter =
         STATUS_FILTERS[filter.providerStatus as keyof typeof STATUS_FILTERS];
       if (statusFilter) {

--- a/src/ui/common/types/bsn.ts
+++ b/src/ui/common/types/bsn.ts
@@ -1,7 +1,11 @@
+export type BsnType = "COSMOS" | "ROLLUP";
+
 export interface Bsn {
   id: string;
   name: string;
   description: string;
   logoUrl: string;
   activeTvl?: number;
+  type: BsnType;
+  allowlist?: string[]; // BTC FP pubkeys (hex)
 }


### PR DESCRIPTION
https://www.figma.com/design/NjxA7LgQzuLhGGWfOX0hJm/Super-dApp?node-id=3072-786684&t=OPO7CBxS3TNPoNK8-4

**Allowlist Filtering and Selection:**
- Added `isAllowlisted` property to the finality provider API interface, type, and API mapping, enabling allowlist status to be used throughout the app [[1]](diffhunk://#diff-65a6c64de4eb9c13b2edccd94dd8d6fb5136453f64ea7fa335e748fc7d8efb1dR33) [[2]](diffhunk://#diff-6b51e63fc739bab841e76b2cffcefed6f745f33f1f994d768368fccb4f71846bR15) [[3]](diffhunk://#diff-65a6c64de4eb9c13b2edccd94dd8d6fb5136453f64ea7fa335e748fc7d8efb1dR103).
- Implemented the `FinalityProviderAllowlistFilter` UI component, allowing users to filter providers by allowlist status for non-Babylon BSNs.
- Updated provider row selection logic to restrict selection to allowlisted providers for non-Babylon BSNs.

<img width="860" height="794" alt="Screenshot 2025-09-04 at 1 37 33 AM" src="https://github.com/user-attachments/assets/b03953a4-b8d3-4db9-a05f-fbfb6ee94df6" />
<img width="911" height="811" alt="Screenshot 2025-09-04 at 1 21 25 AM" src="https://github.com/user-attachments/assets/accb645b-8289-4359-be4d-e4f60d1a624c" />
<img width="959" height="691" alt="Screenshot 2025-09-04 at 1 21 01 AM" src="https://github.com/user-attachments/assets/7c33f1c3-79d4-4c4d-97b4-746604e4de63" />

<img width="864" height="776" alt="Screenshot 2025-09-04 at 1 39 00 AM" src="https://github.com/user-attachments/assets/d3be16bd-3282-458a-994a-8cd46dde1134" />
<img width="855" height="684" alt="Screenshot 2025-09-04 at 1 38 49 AM" src="https://github.com/user-attachments/assets/0eb58dff-075c-4b5a-b080-67fde6a72600" />

