### PR TITLE
chore: change web description from btc staking dashboard to staking d…

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <link rel="canonical" href="%NEXT_PUBLIC_CANONICAL%" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="Babylon - Staking Dashboard" />
-    <meta name="description" content="BTC Staking Dashboard" key="desc" />
-    <meta property="og:description" content="BTC Staking Dashboard" />
+    <meta name="description" content="Staking Dashboard" key="desc" />
+    <meta property="og:description" content="Staking Dashboard" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="2048" />
     <meta property="og:image:height" content="1170" />
@@ -16,8 +16,8 @@
       content="https://btcstaking.babylonlabs.io/og.png"
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="BTC Staking Dashboard" />
-    <meta name="twitter:description" content="BTC Staking Dashboard" />
+    <meta name="twitter:title" content="Staking Dashboard" />
+    <meta name="twitter:description" content="Staking Dashboard" />
     <meta
       name="twitter:image"
       content="https://btcstaking.babylonlabs.io/og.png"


### PR DESCRIPTION
Remove the keyword of `BTC` from description so the thumbnail link change from below to `Staking Dashboard` instead

<img width="340" height="236" alt="image" src="https://github.com/user-attachments/assets/265629e6-782c-4309-9d0e-a42e6b69f786" />
