### PR TITLE
feat: add tooltip to apr stats depending on phase #1291

### DIFF
--- a/src/ui/common/components/Stats/Stats.tsx
+++ b/src/ui/common/components/Stats/Stats.tsx
@@ -56,7 +56,7 @@ export const Stats = memo(() => {
           tooltip={
             FeatureFlagService.IsPhase3Enabled
               ? "This is the maximum achievable APR based on delegating to the highest-yielding BSNs, including Babylon Genesis. Actual APR may vary depending on your selection."
-              : '"Annual Percentage Reward" (APR) is a dynamic estimate of the annualized staking reward rate based on current network conditions, and it refers to staking rewards rather than traditional lending interest. Rewards are distributed in BABY tokens but shown as a Bitcoin-equivalent rate relative to the Bitcoin initially staked. APR is calculated using U.S. dollar values for Bitcoin and BABY from independent, reputable sources. The APR shown is an approximate figure that can fluctuate, and the displayed value may not always be completely accurate. Actual rewards are not guaranteed and may vary over time. Staking carries exposure to slashing and other risks.'
+              : 'Annual Percentage Reward (APR) is a dynamic estimate of the annualized staking reward rate based on current network conditions, and it refers to staking rewards rather than traditional lending interest. Rewards are distributed in BABY tokens but shown as a Bitcoin-equivalent rate relative to the Bitcoin initially staked. APR is calculated using U.S. dollar values for Bitcoin and BABY from independent, reputable sources. The APR shown is an approximate figure that can fluctuate, and the displayed value may not always be completely accurate. Actual rewards are not guaranteed and may vary over time. Staking carries exposure to slashing and other risks.'
           }
         />
 

--- a/src/ui/common/components/Stats/Stats.tsx
+++ b/src/ui/common/components/Stats/Stats.tsx
@@ -53,6 +53,11 @@ export const Stats = memo(() => {
           loading={isLoading}
           title={`${coinSymbol} Staking APR`}
           value={`${formatter.format(network === Network.MAINNET && stakingAPR ? stakingAPR * 100 : 0)}%`}
+          tooltip={
+            FeatureFlagService.IsPhase3Enabled
+              ? "This is the maximum achievable APR based on delegating to the highest-yielding BSNs, including Babylon Genesis. Actual APR may vary depending on your selection."
+              : '"Annual Percentage Reward" (APR) is a dynamic estimate of the annualized staking reward rate based on current network conditions, and it refers to staking rewards rather than traditional lending interest. Rewards are distributed in BABY tokens but shown as a Bitcoin-equivalent rate relative to the Bitcoin initially staked. APR is calculated using U.S. dollar values for Bitcoin and BABY from independent, reputable sources. The APR shown is an approximate figure that can fluctuate, and the displayed value may not always be completely accurate. Actual rewards are not guaranteed and may vary over time. Staking carries exposure to slashing and other risks.'
+          }
         />
 
         {FeatureFlagService.IsPhase3Enabled ? (


### PR DESCRIPTION
phase 3:
<img width="406" height="180" alt="image" src="https://github.com/user-attachments/assets/51bea20c-089f-40fb-85b2-38c8fccb7335" />

phase 2:
<img width="377" height="365" alt="image" src="https://github.com/user-attachments/assets/573f0a09-c81b-4966-8d3e-b951ea0b0fec" />

Closes: #1291