### PR TITLE
feat: keep form data in memory

### DIFF
--- a/src/ui/baby/layout.tsx
+++ b/src/ui/baby/layout.tsx
@@ -112,7 +112,7 @@ function BabyLayoutContent() {
       as="main"
       className="flex flex-col gap-[3rem] pb-24 max-w-[760px] mx-auto flex-1"
     >
-      <Tabs items={fallbackTabItems} defaultActiveTab="stake" />
+      <Tabs items={fallbackTabItems} defaultActiveTab="stake" keepMounted />
     </Container>
   );
 
@@ -132,6 +132,7 @@ function BabyLayoutContent() {
                     defaultActiveTab="stake"
                     activeTab={activeTab}
                     onTabChange={(tabId) => setActiveTab(tabId as TabId)}
+                    keepMounted
                   />
                 </Container>
               </AuthGuard>

--- a/src/ui/baby/widgets/StakingForm/BabyFormPersistence.tsx
+++ b/src/ui/baby/widgets/StakingForm/BabyFormPersistence.tsx
@@ -1,0 +1,64 @@
+import { useFormContext, useWatch } from "@babylonlabs-io/core-ui";
+import { useEffect, useMemo, useRef } from "react";
+
+import {
+  useFormPersistenceState,
+  type BabyStakeDraft,
+} from "@/ui/common/state/FormPersistenceState";
+
+export function BabyFormPersistence() {
+  const { setValue, control } = useFormContext<BabyStakeDraft>();
+  const { babyStakeDraft, setBabyStakeDraft } = useFormPersistenceState();
+  const hasHydratedRef = useRef(false);
+
+  const amount = useWatch({ control, name: "amount" });
+  const validatorAddresses = useWatch({ control, name: "validatorAddresses" });
+  const feeAmount = useWatch({ control, name: "feeAmount" });
+
+  // Hydrate once on mount
+  useEffect(() => {
+    if (hasHydratedRef.current) return;
+
+    if (babyStakeDraft) {
+      if (babyStakeDraft.amount !== undefined) {
+        setValue("amount", babyStakeDraft.amount, {
+          shouldValidate: true,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+      if (babyStakeDraft.validatorAddresses !== undefined) {
+        setValue("validatorAddresses", babyStakeDraft.validatorAddresses, {
+          shouldValidate: true,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+      if (babyStakeDraft.feeAmount !== undefined) {
+        setValue("feeAmount", babyStakeDraft.feeAmount, {
+          shouldValidate: true,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+    }
+
+    hasHydratedRef.current = true;
+  }, [babyStakeDraft, setValue]);
+
+  const draft = useMemo(
+    () => ({
+      amount,
+      validatorAddresses,
+      feeAmount,
+    }),
+    [amount, validatorAddresses, feeAmount],
+  );
+
+  // Persist on change
+  useEffect(() => {
+    setBabyStakeDraft(draft);
+  }, [draft, setBabyStakeDraft]);
+
+  return null;
+}

--- a/src/ui/baby/widgets/StakingForm/index.tsx
+++ b/src/ui/baby/widgets/StakingForm/index.tsx
@@ -8,6 +8,8 @@ import { SubmitButton } from "@/ui/baby/widgets/SubmitButton";
 import { ValidatorField } from "@/ui/baby/widgets/ValidatorField";
 import { FormAlert } from "@/ui/common/components/Multistaking/MultistakingForm/FormAlert";
 
+import { BabyFormPersistence } from "./BabyFormPersistence";
+
 interface FormFields {
   amount: number;
   validatorAddresses: string[];
@@ -44,6 +46,7 @@ export default function StakingForm({
       className="flex flex-col gap-2 h-[500px]"
       onSubmit={handlePreview}
     >
+      <BabyFormPersistence />
       <AmountField balance={availableBalance} price={babyPrice} />
       <ValidatorField />
       <FeeField babyPrice={babyPrice} calculateFee={calculateFee} />

--- a/src/ui/common/components/Multistaking/MultistakingForm/BtcFormPersistence.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/BtcFormPersistence.tsx
@@ -1,0 +1,94 @@
+import { useFormContext, useWatch } from "@babylonlabs-io/core-ui";
+import { useEffect, useMemo, useRef } from "react";
+
+import {
+  useFormPersistenceState,
+  type BtcStakeDraft,
+} from "@/ui/common/state/FormPersistenceState";
+import { useStakingState } from "@/ui/common/state/StakingState";
+
+export function BtcFormPersistence() {
+  const { setValue, control } = useFormContext<BtcStakeDraft>();
+  const { btcStakeDraft, setBtcStakeDraft } = useFormPersistenceState();
+  const { stakingInfo } = useStakingState();
+  const hasHydratedRef = useRef(false);
+
+  const finalityProviders = useWatch({ control, name: "finalityProviders" });
+  const amount = useWatch({ control, name: "amount" });
+  const term = useWatch({ control, name: "term" });
+  const feeRate = useWatch({ control, name: "feeRate" });
+  const feeAmount = useWatch({ control, name: "feeAmount" });
+
+  // Hydrate once on mount
+  useEffect(() => {
+    if (hasHydratedRef.current) return;
+
+    if (btcStakeDraft) {
+      if (btcStakeDraft.finalityProviders) {
+        setValue("finalityProviders", btcStakeDraft.finalityProviders, {
+          shouldValidate: false,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+      if (btcStakeDraft.amount !== undefined) {
+        setValue("amount", btcStakeDraft.amount, {
+          shouldValidate: true,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+      if (btcStakeDraft.term !== undefined) {
+        setValue("term", btcStakeDraft.term, {
+          shouldValidate: false,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+      if (btcStakeDraft.feeRate !== undefined) {
+        setValue("feeRate", btcStakeDraft.feeRate, {
+          shouldValidate: true,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+      if (btcStakeDraft.feeAmount !== undefined) {
+        setValue("feeAmount", btcStakeDraft.feeAmount, {
+          shouldValidate: true,
+          shouldDirty: false,
+          shouldTouch: false,
+        });
+      }
+    } else if (
+      stakingInfo?.defaultFeeRate !== undefined &&
+      (feeRate === undefined || feeRate === "")
+    ) {
+      // Apply default only when no persisted draft and no current value
+      setValue("feeRate", stakingInfo.defaultFeeRate.toString(), {
+        shouldValidate: true,
+        shouldDirty: false,
+        shouldTouch: false,
+      });
+    }
+
+    hasHydratedRef.current = true;
+  }, [btcStakeDraft, stakingInfo?.defaultFeeRate, feeRate, setValue]);
+
+  const draft = useMemo(
+    () => ({
+      finalityProviders,
+      amount,
+      term,
+      feeRate,
+      feeAmount,
+    }),
+    [finalityProviders, amount, term, feeRate, feeAmount],
+  );
+
+  // Persist on change
+  useEffect(() => {
+    setBtcStakeDraft(draft);
+  }, [draft, setBtcStakeDraft]);
+
+  return null;
+}

--- a/src/ui/common/components/Multistaking/MultistakingForm/MultistakingFormContent.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/MultistakingFormContent.tsx
@@ -6,6 +6,7 @@ import { useBTCWallet } from "@/ui/common/context/wallet/BTCWalletProvider";
 import { useStakingState } from "@/ui/common/state/StakingState";
 
 import { AmountSection } from "./AmountSection";
+import { BtcFormPersistence } from "./BtcFormPersistence";
 import { ConnectButton } from "./ConnectButton";
 import { FinalityProvidersSection } from "./FinalityProvidersSection";
 import { FormAlert } from "./FormAlert";
@@ -27,6 +28,8 @@ export function MultistakingFormContent() {
 
       <HiddenField name="feeRate" defaultValue="0" />
       <HiddenField name="feeAmount" defaultValue="0" />
+
+      <BtcFormPersistence />
 
       <div className="flex flex-col gap-2">
         <FinalityProvidersSection />

--- a/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
+++ b/src/ui/common/components/Multistaking/MultistakingForm/StakingFeesSection.tsx
@@ -11,7 +11,6 @@ import { getNetworkConfigBTC } from "@/ui/common/config/network/btc";
 import { BBN_FEE_AMOUNT } from "@/ui/common/constants";
 import { usePrice } from "@/ui/common/hooks/client/api/usePrices";
 import { useStakingService } from "@/ui/common/hooks/services/useStakingService";
-import { useStakingState } from "@/ui/common/state/StakingState";
 import { satoshiToBtc } from "@/ui/common/utils/btc";
 import { calculateTokenValueInCurrency } from "@/ui/common/utils/formatCurrency";
 import { maxDecimals } from "@/ui/common/utils/maxDecimals";
@@ -30,17 +29,6 @@ export function StakingFeesSection() {
   );
 
   const { calculateFeeAmount } = useStakingService();
-  const { stakingInfo } = useStakingState();
-
-  useEffect(() => {
-    if (stakingInfo?.defaultFeeRate !== undefined) {
-      setValue("feeRate", stakingInfo.defaultFeeRate.toString(), {
-        shouldValidate: true,
-        shouldDirty: true,
-        shouldTouch: true,
-      });
-    }
-  }, [stakingInfo?.defaultFeeRate, setValue]);
 
   useEffect(() => {
     let cancelled = false;
@@ -162,6 +150,7 @@ export function StakingFeesSection() {
         open={feeModalVisible}
         onClose={() => setFeeModalVisible(false)}
         onSubmit={handleFeeRateSubmit}
+        currentFeeRate={Number(feeRate || 0)}
       />
     </>
   );

--- a/src/ui/common/components/Staking/FeeModal/index.tsx
+++ b/src/ui/common/components/Staking/FeeModal/index.tsx
@@ -22,9 +22,15 @@ interface FeeModalProps {
   open?: boolean;
   onSubmit?: (value: number) => void;
   onClose?: () => void;
+  currentFeeRate?: number;
 }
 
-export function FeeModal({ open, onSubmit, onClose }: FeeModalProps) {
+export function FeeModal({
+  open,
+  onSubmit,
+  onClose,
+  currentFeeRate,
+}: FeeModalProps) {
   const [selectedValue, setSelectedValue] = useState("");
   const [customFee, setCustomFee] = useState("");
   const customFeeRef = useRef<HTMLInputElement>(null);
@@ -44,6 +50,32 @@ export function FeeModal({ open, onSubmit, onClose }: FeeModalProps) {
       customFeeRef.current?.focus();
     }
   }, [selectedValue]);
+
+  // Initialize selection based on current fee rate when opening
+  useEffect(() => {
+    if (!open || isLoading) return;
+
+    const fee = Number(currentFeeRate);
+    if (!fee || !Number.isFinite(fee)) {
+      setSelectedValue("");
+      setCustomFee("");
+      return;
+    }
+
+    if (fee === fastestFee) {
+      setSelectedValue("fast");
+      setCustomFee("");
+    } else if (fee === mediumFee) {
+      setSelectedValue("medium");
+      setCustomFee("");
+    } else if (fee === lowestFee) {
+      setSelectedValue("slow");
+      setCustomFee("");
+    } else {
+      setSelectedValue("custom");
+      setCustomFee(fee.toString());
+    }
+  }, [open, isLoading, currentFeeRate, fastestFee, mediumFee, lowestFee]);
 
   const feeOptions = [
     {

--- a/src/ui/common/components/Tabs/Tabs.tsx
+++ b/src/ui/common/components/Tabs/Tabs.tsx
@@ -13,6 +13,7 @@ interface TabsProps {
   activeTab?: string;
   onTabChange?: (tabId: string) => void;
   className?: string;
+  keepMounted?: boolean;
 }
 
 export const Tabs = ({
@@ -21,6 +22,7 @@ export const Tabs = ({
   activeTab: controlledActiveTab,
   onTabChange,
   className,
+  keepMounted,
 }: TabsProps) => {
   const [internalActiveTab, setInternalActiveTab] = useState(
     defaultActiveTab || items[0]?.id || "",
@@ -69,14 +71,30 @@ export const Tabs = ({
         ))}
       </div>
 
-      <div
-        className="mt-6 min-h-[450px]"
-        role="tabpanel"
-        id={`panel-${activeTab}`}
-        aria-labelledby={`tab-${activeTab}`}
-      >
-        {activeContent}
-      </div>
+      {keepMounted ? (
+        <div className="mt-6 min-h-[450px]">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              role="tabpanel"
+              id={`panel-${item.id}`}
+              aria-labelledby={`tab-${item.id}`}
+              className={twMerge(activeTab === item.id ? "" : "hidden")}
+            >
+              {item.content}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div
+          className="mt-6 min-h-[450px]"
+          role="tabpanel"
+          id={`panel-${activeTab}`}
+          aria-labelledby={`tab-${activeTab}`}
+        >
+          {activeContent}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/ui/common/page.tsx
+++ b/src/ui/common/page.tsx
@@ -68,6 +68,7 @@ const Home = () => {
         defaultActiveTab="stake"
         activeTab={activeTab}
         onTabChange={setActiveTab}
+        keepMounted
       />
     </Container>
   );

--- a/src/ui/common/state/FormPersistenceState.tsx
+++ b/src/ui/common/state/FormPersistenceState.tsx
@@ -1,0 +1,55 @@
+import { useMemo, useState, type PropsWithChildren } from "react";
+
+import { createStateUtils } from "@/ui/common/utils/createStateUtils";
+
+export type BtcStakeDraft = {
+  finalityProviders?: Record<string, string>;
+  amount?: string;
+  term?: string;
+  feeRate?: string;
+  feeAmount?: string;
+};
+
+export type BabyStakeDraft = {
+  amount?: string;
+  validatorAddresses?: string[];
+  feeAmount?: string;
+};
+
+interface FormPersistenceContext {
+  btcStakeDraft?: BtcStakeDraft | undefined;
+  babyStakeDraft?: BabyStakeDraft | undefined;
+  setBtcStakeDraft: (draft?: BtcStakeDraft) => void;
+  setBabyStakeDraft: (draft?: BabyStakeDraft) => void;
+}
+
+const { StateProvider, useState: useFormPersistenceState } =
+  createStateUtils<FormPersistenceContext>({
+    btcStakeDraft: undefined,
+    babyStakeDraft: undefined,
+    setBtcStakeDraft: () => {},
+    setBabyStakeDraft: () => {},
+  });
+
+export function FormPersistenceState({ children }: PropsWithChildren) {
+  const [btcStakeDraft, setBtcStakeDraft] = useState<BtcStakeDraft | undefined>(
+    undefined,
+  );
+  const [babyStakeDraft, setBabyStakeDraft] = useState<
+    BabyStakeDraft | undefined
+  >(undefined);
+
+  const context = useMemo(
+    () => ({
+      btcStakeDraft,
+      babyStakeDraft,
+      setBtcStakeDraft,
+      setBabyStakeDraft,
+    }),
+    [btcStakeDraft, babyStakeDraft, setBtcStakeDraft, setBabyStakeDraft],
+  );
+
+  return <StateProvider value={context}>{children}</StateProvider>;
+}
+
+export { useFormPersistenceState };

--- a/src/ui/common/state/index.tsx
+++ b/src/ui/common/state/index.tsx
@@ -18,12 +18,14 @@ import { BalanceState } from "./BalanceState";
 import { DelegationState } from "./DelegationState";
 import { DelegationV2State } from "./DelegationV2State";
 import { FinalityProviderState } from "./FinalityProviderState";
+import { FormPersistenceState } from "./FormPersistenceState";
 import { RewardsState } from "./RewardState";
 import { StakingExpansionState } from "./StakingExpansionState";
 import { StakingState } from "./StakingState";
 
 // The order of the states is important for the state provider
 const STATE_LIST = [
+  FormPersistenceState,
   DelegationState,
   DelegationV2State,
   FinalityProviderState,


### PR DESCRIPTION
1. Added `keepMounted` to `Tabs`

2. Added `FormPersistenceState` provider that wraps app for cross-route in-memory drafts

3. `FeeModal` now takes `currentFeeRate` and preselects fast/medium/slow/custom

https://github.com/user-attachments/assets/a618bea4-740f-4ff2-a83e-35daf5aa1153

Closes: #1403
