### PR TITLE
fix: remove the extra / at the end of the babylon rpc or lcd url

### DIFF
--- a/src/ui/common/config/network/bbn/bsn-devnet.ts
+++ b/src/ui/common/config/network/bbn/bsn-devnet.ts
@@ -3,13 +3,13 @@ import { getUrlFromEnv } from "./urlUtils";
 export const BSN_DEVNET_RPC_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_RPC_URL,
   "http://localhost:3000",
-  "https://rpc.bsn-devnet.babylonlabs.io/",
+  "https://rpc.bsn-devnet.babylonlabs.io",
 );
 
 export const BSN_DEVNET_LCD_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_LCD_URL,
   "http://localhost:1317",
-  "https://lcd.bsn-devnet.babylonlabs.io/",
+  "https://lcd.bsn-devnet.babylonlabs.io",
 );
 
 export const bbnBsnDevnet = {

--- a/src/ui/common/config/network/bbn/canary.ts
+++ b/src/ui/common/config/network/bbn/canary.ts
@@ -3,13 +3,13 @@ import { getUrlFromEnv } from "./urlUtils";
 export const BBN_CANARY_RPC_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_RPC_URL,
   "http://localhost:3000",
-  "https://rpc.staging.babylonlabs.io/",
+  "https://rpc.staging.babylonlabs.io",
 );
 
 export const BBN_CANARY_LCD_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_LCD_URL,
   "http://localhost:1317",
-  "https://lcd.staging.babylonlabs.io/",
+  "https://lcd.staging.babylonlabs.io",
 );
 
 export const bbnCanary = {

--- a/src/ui/common/config/network/bbn/devnet.ts
+++ b/src/ui/common/config/network/bbn/devnet.ts
@@ -9,7 +9,7 @@ export const BBN_DEVNET_RPC_URL = getUrlFromEnv(
 export const BBN_DEVNET_LCD_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_LCD_URL,
   "http://localhost:1317",
-  "https://lcd-dapp.devnet.babylonlabs.io/",
+  "https://lcd-dapp.devnet.babylonlabs.io",
 );
 
 export const bbnDevnet = {

--- a/src/ui/common/config/network/bbn/edge-devnet.ts
+++ b/src/ui/common/config/network/bbn/edge-devnet.ts
@@ -3,13 +3,13 @@ import { getUrlFromEnv } from "./urlUtils";
 export const BBN_EDGE_DEVNET_RPC_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_RPC_URL,
   "http://localhost:3000",
-  "https://rpc.edge-devnet.babylonlabs.io/",
+  "https://rpc.edge-devnet.babylonlabs.io",
 );
 
 export const BBN_EDGE_DEVNET_LCD_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_LCD_URL,
   "http://localhost:1317",
-  "https://lcd.edge-devnet.babylonlabs.io/",
+  "https://lcd.edge-devnet.babylonlabs.io",
 );
 
 export const bbnEdgeDevnet = {

--- a/src/ui/common/config/network/bbn/mainnet.ts
+++ b/src/ui/common/config/network/bbn/mainnet.ts
@@ -3,13 +3,13 @@ import { getUrlFromEnv } from "./urlUtils";
 export const BBN_MAINNET_RPC_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_RPC_URL,
   "http://localhost:3000",
-  "https://rpc-dapp.babylonlabs.io/",
+  "https://rpc-dapp.babylonlabs.io",
 );
 
 export const BBN_MAINNET_LCD_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_LCD_URL,
   "http://localhost:1317",
-  "https://lcd-dapp.babylonlabs.io/",
+  "https://lcd-dapp.babylonlabs.io",
 );
 
 export const bbnMainnet = {

--- a/src/ui/common/config/network/bbn/testnet.ts
+++ b/src/ui/common/config/network/bbn/testnet.ts
@@ -3,13 +3,13 @@ import { getUrlFromEnv } from "./urlUtils";
 export const BBN_TESTNET_RPC_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_RPC_URL,
   "http://localhost:3000",
-  "https://rpc-dapp.testnet.babylonlabs.io/",
+  "https://rpc-dapp.testnet.babylonlabs.io",
 );
 
 export const BBN_TESTNET_LCD_URL = getUrlFromEnv(
   process.env.NEXT_PUBLIC_BABY_LCD_URL,
   "http://localhost:1317",
-  "https://lcd-dapp.testnet.babylonlabs.io/",
+  "https://lcd-dapp.testnet.babylonlabs.io",
 );
 
 export const bbnTestnet = {


### PR DESCRIPTION
This bug caused double `//` when making lcd requests