### PR TITLE
feat: expansion history reversed

### DIFF
--- a/src/ui/common/hooks/useExpansionHistoryModalData.ts
+++ b/src/ui/common/hooks/useExpansionHistoryModalData.ts
@@ -37,8 +37,15 @@ export function useExpansionHistoryModalData({
     // Show only expansion history (exclude the target delegation itself)
     const historyChain = expansionChain.slice(0, -1);
 
-    return historyChain.map((delegation, index) => {
-      const stepLabel = index === 0 ? "Original Stake" : `Expansion ${index}`;
+    // Reverse the array to show newest first (most recent expansion → original stake)
+    const reversedHistoryChain = [...historyChain].reverse();
+
+    return reversedHistoryChain.map((delegation, index) => {
+      const totalExpansions = historyChain.length;
+      const stepLabel =
+        index === totalExpansions - 1
+          ? "Original Stake"
+          : `Expansion ${totalExpansions - index - 1}`;
       // Options for expansion history: no expansion section, hide expansion completely
       const options = {
         showExpansionSection: false,


### PR DESCRIPTION
- reverses the order of expansion history
- before it was - `original -> staking 1 -> staking 2`
<img width="671" height="842" alt="Screenshot_2025-09-02_16-32-59" src="https://github.com/user-attachments/assets/ab68bbb7-5124-4804-a3d2-c672aec029b3" />

- now it is `staking 2 -> staking 1 -> original`, from recent ones to the older ones

<img width="791" height="1005" alt="Screenshot_2025-09-03_13-52-57" src="https://github.com/user-attachments/assets/d4ab03ae-0bd9-4ed5-a728-29e2ed185766" />


Closes this: https://github.com/babylonlabs-io/simple-staking/issues/1526