### PR TITLE
feat: expansion activity

### DIFF
--- a/src/ui/common/components/Stats/Stats.tsx
+++ b/src/ui/common/components/Stats/Stats.tsx
@@ -56,7 +56,7 @@ export const Stats = memo(() => {
           tooltip={
             FeatureFlagService.IsPhase3Enabled
               ? "This is the maximum achievable APR based on delegating to the highest-yielding BSNs, including Babylon Genesis. Actual APR may vary depending on your selection."
-              : 'Annual Percentage Reward (APR) is a dynamic estimate of the annualized staking reward rate based on current network conditions, and it refers to staking rewards rather than traditional lending interest. Rewards are distributed in BABY tokens but shown as a Bitcoin-equivalent rate relative to the Bitcoin initially staked. APR is calculated using U.S. dollar values for Bitcoin and BABY from independent, reputable sources. The APR shown is an approximate figure that can fluctuate, and the displayed value may not always be completely accurate. Actual rewards are not guaranteed and may vary over time. Staking carries exposure to slashing and other risks.'
+              : "Annual Percentage Reward (APR) is a dynamic estimate of the annualized staking reward rate based on current network conditions, and it refers to staking rewards rather than traditional lending interest. Rewards are distributed in BABY tokens but shown as a Bitcoin-equivalent rate relative to the Bitcoin initially staked. APR is calculated using U.S. dollar values for Bitcoin and BABY from independent, reputable sources. The APR shown is an approximate figure that can fluctuate, and the displayed value may not always be completely accurate. Actual rewards are not guaranteed and may vary over time. Staking carries exposure to slashing and other risks."
           }
         />
 

--- a/src/ui/common/hooks/services/useActivityCardTransformation.ts
+++ b/src/ui/common/hooks/services/useActivityCardTransformation.ts
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+
+import { getActionButton } from "@/ui/common/components/ActivityCard/utils/actionButtonUtils";
+import {
+  ActivityCardTransformOptions,
+  transformDelegationToActivityCard,
+} from "@/ui/common/components/ActivityCard/utils/activityCardTransformers";
+import { ActionType } from "@/ui/common/hooks/services/useDelegationService";
+import {
+  DelegationV2,
+  DelegationWithFP,
+} from "@/ui/common/types/delegationsV2";
+import { FinalityProvider } from "@/ui/common/types/finalityProviders";
+
+export interface ActivityCardData
+  extends ReturnType<typeof transformDelegationToActivityCard> {
+  primaryAction?: ReturnType<typeof getActionButton>;
+}
+
+/**
+ * Hook for transforming delegations into activity card data.
+ * Handles transformation to card format and addition of action buttons.
+ *
+ * @param delegations - The validated delegations to transform
+ * @param finalityProviderMap - Map of finality providers for FP lookup
+ * @param openConfirmationModal - Function to open confirmation modal
+ * @param isStakingManagerReady - Whether staking manager is ready for actions
+ * @returns Array of transformed activity card data
+ */
+export function useActivityCardTransformation(
+  delegations: DelegationV2[],
+  finalityProviderMap: Map<string, FinalityProvider>,
+  openConfirmationModal: (
+    action: ActionType,
+    delegation: DelegationWithFP,
+  ) => void,
+  isStakingManagerReady: boolean,
+): ActivityCardData[] {
+  return useMemo(() => {
+    return delegations.map((delegation) => {
+      // Transform delegation to activity card format
+      const options: ActivityCardTransformOptions = {
+        showExpansionSection: true,
+      };
+      const cardData = transformDelegationToActivityCard(
+        delegation,
+        finalityProviderMap,
+        options,
+      );
+
+      // Create delegation with FP for action button logic
+      // Use the first FP [0] for backward compatibility with action button logic
+      // which expects a single FP to determine button state. The full BSN/FP pairs
+      // are properly displayed in the card's grouped details section
+      const delegation_v2 = delegation as DelegationV2;
+      const fp =
+        Array.isArray(delegation_v2.finalityProviderBtcPksHex) &&
+        delegation_v2.finalityProviderBtcPksHex.length > 0
+          ? finalityProviderMap.get(delegation_v2.finalityProviderBtcPksHex[0])
+          : undefined;
+
+      const delegationWithFP: DelegationWithFP = {
+        ...delegation_v2,
+        fp,
+      } as DelegationWithFP;
+
+      // Add action button if applicable
+      const primaryAction = getActionButton(
+        delegationWithFP,
+        openConfirmationModal,
+        isStakingManagerReady,
+      );
+
+      return {
+        ...cardData,
+        primaryAction,
+      };
+    });
+  }, [
+    delegations,
+    finalityProviderMap,
+    openConfirmationModal,
+    isStakingManagerReady,
+  ]);
+}

--- a/src/ui/common/hooks/services/useActivityDelegations.ts
+++ b/src/ui/common/hooks/services/useActivityDelegations.ts
@@ -1,0 +1,75 @@
+import { useBTCWallet } from "@/ui/common/context/wallet/BTCWalletProvider";
+import { useDelegationService } from "@/ui/common/hooks/services/useDelegationService";
+import { useExpansionVisibilityService } from "@/ui/common/hooks/services/useExpansionVisibilityService";
+import { useStakingManagerService } from "@/ui/common/hooks/services/useStakingManagerService";
+import { useFinalityProviderState } from "@/ui/common/state/FinalityProviderState";
+
+import {
+  ActivityCardData,
+  useActivityCardTransformation,
+} from "./useActivityCardTransformation";
+import { useActivityValidation } from "./useActivityValidation";
+
+/**
+ * Main hook orchestrating all activity-related delegation logic.
+ * Combines validation, visibility filtering, and card transformation.
+ */
+export function useActivityDelegations() {
+  // Core delegation and wallet data
+  const {
+    processing,
+    confirmationModal,
+    delegations,
+    isLoading: isDelegationLoading,
+    validations,
+    executeDelegationAction,
+    openConfirmationModal,
+    closeConfirmationModal,
+  } = useDelegationService();
+
+  const { isLoading: isStakingManagerLoading } = useStakingManagerService();
+  const isStakingManagerReady = !isStakingManagerLoading;
+
+  const { finalityProviderMap } = useFinalityProviderState();
+  const { publicKeyNoCoord } = useBTCWallet();
+
+  // Expansion visibility service for filtering logic
+  const { getActivityTabDelegations } =
+    useExpansionVisibilityService(publicKeyNoCoord);
+
+  // Step 1: Apply validation logic (including special VERIFIED expansion handling)
+  const validatedDelegations = useActivityValidation(
+    delegations,
+    validations,
+    publicKeyNoCoord,
+  );
+
+  // Step 2: Apply expansion visibility filtering
+  const visibleDelegations = getActivityTabDelegations(validatedDelegations);
+
+  // Step 3: Transform to activity card data
+  const activityData: ActivityCardData[] = useActivityCardTransformation(
+    visibleDelegations,
+    finalityProviderMap,
+    openConfirmationModal,
+    isStakingManagerReady,
+  );
+
+  return {
+    // Transformed data ready for rendering
+    activityData,
+
+    // Loading states
+    isLoading: isDelegationLoading,
+    isStakingManagerReady,
+
+    // Modal states and actions
+    processing,
+    confirmationModal,
+    executeDelegationAction,
+    closeConfirmationModal,
+
+    // Raw delegations for modals that need them
+    delegations,
+  };
+}

--- a/src/ui/common/hooks/services/useActivityDelegations.ts
+++ b/src/ui/common/hooks/services/useActivityDelegations.ts
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { useBTCWallet } from "@/ui/common/context/wallet/BTCWalletProvider";
 import { useDelegationService } from "@/ui/common/hooks/services/useDelegationService";
 import { useExpansionVisibilityService } from "@/ui/common/hooks/services/useExpansionVisibilityService";
@@ -55,21 +57,33 @@ export function useActivityDelegations() {
     isStakingManagerReady,
   );
 
-  return {
-    // Transformed data ready for rendering
-    activityData,
+  return useMemo(
+    () => ({
+      // Transformed data ready for rendering
+      activityData,
 
-    // Loading states
-    isLoading: isDelegationLoading,
-    isStakingManagerReady,
+      // Loading states
+      isLoading: isDelegationLoading,
+      isStakingManagerReady,
 
-    // Modal states and actions
-    processing,
-    confirmationModal,
-    executeDelegationAction,
-    closeConfirmationModal,
+      // Modal states and actions
+      processing,
+      confirmationModal,
+      executeDelegationAction,
+      closeConfirmationModal,
 
-    // Raw delegations for modals that need them
-    delegations,
-  };
+      // Raw delegations for modals that need them
+      delegations,
+    }),
+    [
+      activityData,
+      isDelegationLoading,
+      isStakingManagerReady,
+      processing,
+      confirmationModal,
+      executeDelegationAction,
+      closeConfirmationModal,
+      delegations,
+    ],
+  );
 }

--- a/src/ui/common/hooks/services/useActivityValidation.ts
+++ b/src/ui/common/hooks/services/useActivityValidation.ts
@@ -1,0 +1,38 @@
+import { useMemo } from "react";
+
+import { DelegationV2 } from "@/ui/common/types/delegationsV2";
+import { isValidBroadcastedExpansion } from "@/ui/common/utils/stakingExpansionValidation";
+
+/**
+ * Hook for validating delegations in the Activity tab.
+ * Handles both regular UTXO validation and special cases for VERIFIED broadcasted expansions.
+ *
+ * @param delegations - The raw delegations from the delegation service
+ * @param validations - The validation results from useUtxoValidation
+ * @param publicKeyNoCoord - The user's public key for localStorage access
+ * @returns Filtered array of delegations that should be considered for display
+ */
+export function useActivityValidation(
+  delegations: DelegationV2[],
+  validations: Record<string, { valid: boolean }>,
+  publicKeyNoCoord: string | undefined,
+): DelegationV2[] {
+  return useMemo(() => {
+    return delegations.filter((delegation) => {
+      const validation = validations[delegation.stakingTxHashHex];
+      const { valid } = validation || { valid: false };
+
+      // Include if it passes regular UTXO validation
+      if (valid) return true;
+
+      // Special case: Include VERIFIED broadcasted expansions even without valid UTXOs
+      // This is because expansions are broadcasted but not yet confirmed on Bitcoin,
+      // so they don't have valid UTXOs yet but should still be shown in Activity tab
+      if (isValidBroadcastedExpansion(delegation, publicKeyNoCoord)) {
+        return true;
+      }
+
+      return false;
+    });
+  }, [delegations, validations, publicKeyNoCoord]);
+}

--- a/src/ui/common/utils/stakingExpansionValidation.ts
+++ b/src/ui/common/utils/stakingExpansionValidation.ts
@@ -38,7 +38,8 @@ export const isValidBroadcastedExpansion = (
   delegation: DelegationV2,
   publicKeyNoCoord: string | undefined,
 ): boolean => {
-  // Only applies to VERIFIED delegations with previous staking tx
+  // Early return false if delegation is NOT in VERIFIED state
+  // or does NOT have a previous staking tx (not an expansion)
   if (
     delegation.state !== DelegationV2StakingState.VERIFIED ||
     !delegation.previousStakingTxHashHex

--- a/src/ui/common/utils/stakingExpansionValidation.ts
+++ b/src/ui/common/utils/stakingExpansionValidation.ts
@@ -1,4 +1,9 @@
 import type { StakingExpansionFormData } from "@/ui/common/state/StakingExpansionTypes";
+import {
+  DelegationV2,
+  DelegationV2StakingState,
+} from "@/ui/common/types/delegationsV2";
+import { isExpansionBroadcasted } from "@/ui/common/utils/local_storage/expansionStorage";
 
 /**
  * Validation helper for StakingExpansionFormData
@@ -19,4 +24,28 @@ export const validateExpansionFormData = (
     data.stakingTimelock &&
     data.stakingTimelock > 0
   );
+};
+
+/**
+ * Validates whether a VERIFIED delegation should be included in Activity
+ * even when it doesn't have valid UTXOs yet (expansion case).
+ *
+ * @param delegation - The delegation to validate
+ * @param publicKeyNoCoord - The user's public key for localStorage access
+ * @returns true if this is a valid broadcasted expansion that should be shown
+ */
+export const isValidBroadcastedExpansion = (
+  delegation: DelegationV2,
+  publicKeyNoCoord: string | undefined,
+): boolean => {
+  // Only applies to VERIFIED delegations with previous staking tx
+  if (
+    delegation.state !== DelegationV2StakingState.VERIFIED ||
+    !delegation.previousStakingTxHashHex
+  ) {
+    return false;
+  }
+
+  // Check if it's a broadcasted expansion in localStorage
+  return isExpansionBroadcasted(delegation.stakingTxHashHex, publicKeyNoCoord);
 };


### PR DESCRIPTION
- solves the activity tab problem for exansion
- split the logic in activity list
- formats the `src/ui/common/components/Stats/Stats.tsx` because of `npm run format:fix`

Closes https://github.com/babylonlabs-io/simple-staking/issues/1532